### PR TITLE
ISAICP-2524

### DIFF
--- a/web/profiles/joinup/config/install/user.role.moderator.yml
+++ b/web/profiles/joinup/config/install/user.role.moderator.yml
@@ -10,6 +10,7 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'add og menu instance entities'
+  - 'administer group'
   - 'administer nodes'
   - 'administer users'
   - 'administer views'


### PR DESCRIPTION
Until permission override is allowed in OG (just like node_access_strict was being used), the moderator will use the 'administer group' OG permission to have global access to the groups.