### PR TITLE
changed virtuoso restart to supervisorctl

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -437,7 +437,7 @@
         <echo message="Allow importing of RDF data from all directories" />
         <exec dir="${project.basedir}"
               command="sudo sed -i 's/DirsAllowed              = ., \/usr\/share\/virtuoso-opensource-6.1\/vad/DirsAllowed = \//g' /etc/virtuoso-opensource-6.1/virtuoso.ini;
-sudo /etc/init.d/virtuoso-opensource-6.1 restart"
+sudo supervisorctl restart virtuoso"
               checkreturn="true"
               passthru="true" />
         <echo message="Create Solr index" />


### PR DESCRIPTION
Hello!

We fixed some issues in supervisord configuration of our containers. This also concerns virtuoso. It can now be restarted using supervisor:

```sudo supervisorctl restart virtuoso```

This has also the advantage that the Phing becomes independant of the virtuoso version.

Sorry for the BC break!