### PR TITLE
uses chrome as web browser

### DIFF
--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -6,7 +6,7 @@ default:
         - Drupal\joinup\Context\DrupalContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MessageContext
-        - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\joinup\Context\MinkContext
       filters:
         tags: '~@wip'
   extensions:

--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -15,6 +15,7 @@ default:
       files_path: '${behat.files.path}'
       goutte: ~
       javascript_session: 'selenium2'
+      browser_name: chrome
       selenium2:
         wd_host: '${behat.webdriver_url}'
     Drupal\DrupalExtension:

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\joinup\Context;
 
+use Behat\Mink\Driver\GoutteDriver;
 use Drupal\DrupalExtension\Context\MinkContext as DrupalExtensionMinkContext;
 
 /**
@@ -18,29 +19,29 @@ class MinkContext extends DrupalExtensionMinkContext {
    *   File path.
    */
   public function attachFileToField($field, $path) {
-  $field = $this->fixStepArgument($field);
-  if ($this->getMinkParameter('files_path')) {
-    $full_path = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR)
-    . DIRECTORY_SEPARATOR
-      . $path;
-    if (is_file($full_path)) {
-      $path = $full_path;
+    $field = $this->fixStepArgument($field);
+    if ($this->getMinkParameter('files_path')) {
+      $full_path = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR)
+      . DIRECTORY_SEPARATOR
+        . $path;
+      if (is_file($full_path)) {
+        $path = $full_path;
+      }
     }
-  }
-  if (!$this->getSession()->getDriver() instanceof \Behat\Mink\Driver\GoutteDriver) {
-    $temp_zip = tempnam('', 'WebDriverZip');
-    $zip = new \ZipArchive();
-    $zip->open($temp_zip, \ZipArchive::CREATE);
-    $zip->addFile($path, basename($path));
-    $zip->close();
-    $path = $this->getSession()->getDriver()->getWebDriverSession()->file([
-      'file' => base64_encode(file_get_contents($temp_zip)),
-    ]);
-  }
-  $this->getSession()->getPage()->attachFileToField($field, $path);
-  if (isset($temp_zip)) {
-    unlink($temp_zip);
-  }
+    if (!$this->getSession()->getDriver() instanceof GoutteDriver) {
+      $temp_zip = tempnam('', 'WebDriverZip');
+      $zip = new \ZipArchive();
+      $zip->open($temp_zip, \ZipArchive::CREATE);
+      $zip->addFile($path, basename($path));
+      $zip->close();
+      $path = $this->getSession()->getDriver()->getWebDriverSession()->file([
+        'file' => base64_encode(file_get_contents($temp_zip)),
+      ]);
+    }
+    $this->getSession()->getPage()->attachFileToField($field, $path);
+    if (isset($temp_zip)) {
+      unlink($temp_zip);
+    }
   }
 
 }

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -8,32 +8,39 @@ use Drupal\DrupalExtension\Context\MinkContext as DrupalExtensionMinkContext;
  * Provides step definitions for interacting with Mink.
  */
 class MinkContext extends DrupalExtensionMinkContext {
-  
+
+  /**
+   * Attach File to field.
+   *
+   * @param string $field
+   *   Field name.
+   * @param string $path
+   *   File path.
+   */
   public function attachFileToField($field, $path) {
-      $field = $this->fixStepArgument($field);
-
-      if ($this->getMinkParameter('files_path')) {
-          $fullPath = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
-          if (is_file($fullPath)) {
-              $path = $fullPath;
-          }
-      }
-
-      if (!$this->getSession()->getDriver() instanceof \Behat\Mink\Driver\GoutteDriver) {
-          $tempZip = tempnam('', 'WebDriverZip');
-          $zip = new \ZipArchive();
-          $zip->open($tempZip, \ZipArchive::CREATE);
-          $zip->addFile($path, basename($path));
-          $zip->close();
-          $path = $this->getSession()->getDriver()->getWebDriverSession()->file([
-              'file' => base64_encode(file_get_contents($tempZip))
-          ]);
-      }
-
-      $this->getSession()->getPage()->attachFileToField($field, $path);
-
-      if (isset($tempZip)) {
-          unlink($tempZip);
-      }
+  $field = $this->fixStepArgument($field);
+  if ($this->getMinkParameter('files_path')) {
+    $full_path = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR)
+    . DIRECTORY_SEPARATOR
+      . $path;
+    if (is_file($full_path)) {
+      $path = $full_path;
+    }
   }
+  if (!$this->getSession()->getDriver() instanceof \Behat\Mink\Driver\GoutteDriver) {
+    $temp_zip = tempnam('', 'WebDriverZip');
+    $zip = new \ZipArchive();
+    $zip->open($temp_zip, \ZipArchive::CREATE);
+    $zip->addFile($path, basename($path));
+    $zip->close();
+    $path = $this->getSession()->getDriver()->getWebDriverSession()->file([
+      'file' => base64_encode(file_get_contents($temp_zip)),
+    ]);
+  }
+  $this->getSession()->getPage()->attachFileToField($field, $path);
+  if (isset($temp_zip)) {
+    unlink($temp_zip);
+  }
+  }
+
 }

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\joinup\Context;
+
+use Drupal\DrupalExtension\Context\MinkContext as DrupalExtensionMinkContext;
+
+/**
+ * Provides step definitions for interacting with Mink.
+ */
+class MinkContext extends DrupalExtensionMinkContext {
+  
+  public function attachFileToField($field, $path) {
+      $field = $this->fixStepArgument($field);
+
+      if ($this->getMinkParameter('files_path')) {
+          $fullPath = rtrim(realpath($this->getMinkParameter('files_path')), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$path;
+          if (is_file($fullPath)) {
+              $path = $fullPath;
+          }
+      }
+
+      if (!$this->getSession()->getDriver() instanceof Behat\Mink\Driver\GoutteDriver) {
+          $tempZip = tempnam('', 'WebDriverZip');
+          $zip = new \ZipArchive();
+          $zip->open($tempZip, \ZipArchive::CREATE);
+          $zip->addFile($path, basename($path));
+          $zip->close();
+          $path = $this->getSession()->getDriver()->getWebDriverSession()->file([
+              'file' => base64_encode(file_get_contents($tempZip))
+          ]);
+      }
+
+      $this->getSession()->getPage()->attachFileToField($field, $path);
+
+      if (isset($tempZip)) {
+          unlink($tempZip);
+      }
+  }
+}

--- a/tests/src/Context/MinkContext.php
+++ b/tests/src/Context/MinkContext.php
@@ -19,7 +19,7 @@ class MinkContext extends DrupalExtensionMinkContext {
           }
       }
 
-      if (!$this->getSession()->getDriver() instanceof Behat\Mink\Driver\GoutteDriver) {
+      if (!$this->getSession()->getDriver() instanceof \Behat\Mink\Driver\GoutteDriver) {
           $tempZip = tempnam('', 'WebDriverZip');
           $zip = new \ZipArchive();
           $zip->open($tempZip, \ZipArchive::CREATE);


### PR DESCRIPTION
Hi,

We just installed separate containers into continuousphp dedicated to selenium to improve headless web driver stability.
This is an official container from selenium and you can easily use it locally for development purpose.
Just check it out from [Docker Hub](https://hub.docker.com/r/selenium/standalone-chrome/)

Into [continuousphp](https://continuousphp.com), this selenium container is accessible through http://selenium:4444/wd/hub url and the application through http://application. More services will be run from separate containers in the near future.

Regards,
Frederic
