### PR TITLE
PoC: Assure consistent RDF entity IDs

### DIFF
--- a/web/modules/custom/joinup_core/tests/src/Kernel/JoinupKernelTestBase.php
+++ b/web/modules/custom/joinup_core/tests/src/Kernel/JoinupKernelTestBase.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\Tests\joinup_core\Kernel;
+
+use Drupal\Core\Database\Database;
+use Drupal\KernelTests\KernelTestBase;
+use EasyRdf\Http;
+
+/**
+ * Provides a base class for Joinup kernel tests.
+ *
+ * Mainly, assures the connection to the triple store database.
+ */
+abstract class JoinupKernelTestBase extends KernelTestBase {
+
+  /**
+   * The SPARQL database connection.
+   *
+   * @var array
+   */
+  protected $sparqlDatabase;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'rdf_entity',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+
+    if (!$this->setUpSparql()) {
+      $this->markTestSkipped('No Sparql connection available.');
+    }
+    // Test is not compatible with Virtuoso 6.
+    if ($this->detectVirtuoso6()) {
+      $this->markTestSkipped('Skipping: Not running on Virtuoso 6.');
+    }
+  }
+
+  /**
+   * Checks if the triple store is an Virtuoso 6 instance.
+   */
+  protected function detectVirtuoso6() {
+    $client = Http::getDefaultHttpClient();
+    $client->resetParameters(TRUE);
+    $client->setUri("http://{$this->sparqlDatabase['host']}:{$this->sparqlDatabase['port']}/");
+    $client->setMethod('GET');
+    $response = $client->request();
+    $server_header = $response->getHeader('Server');
+    if (strpos($server_header, "Virtuoso/06") === FALSE) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Setup the db connection to the triple store.
+   */
+  protected function setUpSparql() {
+    // If the test is run with argument db url then use it.
+    // export SIMPLETEST_SPARQL_DB='sparql://127.0.0.1:8890/'.
+    $db_url = getenv('SIMPLETEST_SPARQL_DB');
+    if (empty($db_url)) {
+      return FALSE;
+    }
+    $this->sparqlDatabase = Database::convertDbUrlToConnectionInfo($db_url, DRUPAL_ROOT);
+    $this->sparqlDatabase['namespace'] = 'Drupal\\rdf_entity\\Database\\Driver\\sparql';
+    Database::addConnectionInfo('sparql_default', 'default', $this->sparqlDatabase);
+
+    return TRUE;
+  }
+
+}

--- a/web/modules/custom/rdf_entity/rdf_entity.module
+++ b/web/modules/custom/rdf_entity/rdf_entity.module
@@ -81,7 +81,15 @@ function rdf_entity_form_field_storage_config_edit_form_alter(&$form, FormStateI
  */
 function rdf_entity_get_third_party_property(ConfigEntityInterface $object, $property, $column, $default = NULL) {
   $property_value = $object->getThirdPartySetting('rdf_entity', $property, FALSE);
-  if (!is_array($property_value) || !isset($property_value[$column])) {
+
+  if (!is_array($property_value)) {
+    $property_value = [];
+  }
+
+  // The entity 'uri' is a special kind of fish.
+  $property_value += ['id' => ['value' => 'http://purl.org/dc/terms/identifier']];
+
+  if (!isset($property_value[$column])) {
     return $default;
   }
   return $property_value[$column];
@@ -165,9 +173,9 @@ function rdf_entity_form_alter(&$form, FormStateInterface $form_state) {
   /** @var \Drupal\Core\Field\BaseFieldDefinition $base_field */
   foreach ($base_fields as $id => $base_field) {
     $columns = $base_field->getColumns();
-    // The entity id doesn't need a mapping,
-    // as this is the subject of the triple.
-    if ($id == $idKey) {
+    // Entity 'id' and 'url' fields doesn't need a mapping, as they are subject
+    // of the triple.
+    if (in_array($id, [$idKey, 'uri'])) {
       continue;
     }
     foreach ($columns as $column_name => $column) {

--- a/web/modules/custom/rdf_entity/src/Entity/Rdf.php
+++ b/web/modules/custom/rdf_entity/src/Entity/Rdf.php
@@ -32,6 +32,7 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *
  * The class also uses the EntityChangedTrait trait which allows it to record
  * timestamps of save operations.
+ *
  * @ingroup rdf_entity
  *
  * @ContentEntityType(

--- a/web/modules/custom/rdf_entity/src/Entity/Rdf.php
+++ b/web/modules/custom/rdf_entity/src/Entity/Rdf.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\rdf_entity\Entity;
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Entity\ContentEntityBase;
@@ -11,63 +12,27 @@ use Drupal\rdf_entity\RdfInterface;
 use Drupal\Core\Entity\EntityChangedTrait;
 
 /**
- * Defines the ContentEntityExample entity.
+ * Defines the Rdf entity.
  *
+ * The Rdf class defines methods and fields for the Rdf entity.
+ *
+ * Being derived from the ContentEntityBase class, we can override the methods
+ * we want. In our case we want to provide access to the standard fields about
+ * creation and changed time stamps.
+ *
+ * Our interface (see RdfInterface) also exposes the EntityOwnerInterface.
+ * This allows us to provide methods for setting and providing ownership
+ * information.
+ *
+ * The most important part is the definitions of the field properties for this
+ * entity type. These are of the same type as fields added through the GUI, but
+ * they can by changed in code. In the definition we can define if the user with
+ * the rights privileges can influence the presentation (view, edit) of each
+ * field.
+ *
+ * The class also uses the EntityChangedTrait trait which allows it to record
+ * timestamps of save operations.
  * @ingroup rdf_entity
- *
- * This is the main definition of the entity type. From it, an entityType is
- * derived. The most important properties in this example are listed below.
- *
- * id: The unique identifier of this entityType. It follows the pattern
- * 'moduleName_xyz' to avoid naming conflicts.
- *
- * label: Human readable name of the entity type.
- *
- * handlers: Handler classes are used for different tasks. You can use
- * standard handlers provided by D8 or build your own, most probably derived
- * from the standard class. In detail:
- *
- * - view_builder: we use the standard controller to view an instance. It is
- *   called when a route lists an '_entity_view' default for the entityType
- *   (see routing.yml for details. The view can be manipulated by using the
- *   standard drupal tools in the settings.
- *
- * - list_builder: We derive our own list builder class from the
- *   entityListBuilder to control the presentation.
- *   If there is a view available for this entity from the views module, it
- *   overrides the list builder. @todo: any view? naming convention?
- *
- * - form: We derive our own forms to add functionality like additional fields,
- *   redirects etc. These forms are called when the routing list an
- *   '_entity_form' default for the entityType. Depending on the suffix
- *   (.add/.edit/.delete) in the route, the correct form is called.
- *
- * - access: Our own accessController where we determine access rights based on
- *   permissions.
- *
- * More properties:
- *
- *  - base_table: Define the name of the table used to store the data. Make sure
- *    it is unique. The schema is automatically determined from the
- *    BaseFieldDefinitions below. The table is automatically created during
- *    installation.
- *
- *  - fieldable: Can additional fields be added to the entity via the GUI?
- *    Analog to content types.
- *
- *  - entity_keys: How to access the fields. Analog to 'nid' or 'uid'.
- *
- *  - links: Provide links to do standard tasks. The 'edit-form' and
- *    'delete-form' links are added to the list built by the
- *    entityListController. They will show up as action buttons in an additional
- *    column.
- *
- * There are many more properties to be used in an entity type definition. For
- * a complete overview, please refer to the '\Drupal\Core\Entity\EntityType'
- * class definition.
- *
- * The following construct is the actual definition of the entity type which
- * is read and cached. Don't forget to clear cache after changes.
  *
  * @ContentEntityType(
  *   id = "rdf_entity",
@@ -105,35 +70,9 @@ use Drupal\Core\Entity\EntityChangedTrait;
  *   permission_granularity = "bundle",
  *   common_reference_target = TRUE,
  * )
- *
- * The 'links' above are defined by their path. For core to find the
- * corresponding route, the route name must follow the correct pattern:
- *
- * entity.<entity-name>.<link-name> (replace dashes with underscores)
- * Example: 'entity.rdf_entity.canonical'
- *
- * See routing file above for the corresponding implementation
- *
- * The Rdf class defines methods and fields for the Rdf entity.
- *
- * Being derived from the ContentEntityBase class, we can override the methods
- * we want. In our case we want to provide access to the standard fields about
- * creation and changed time stamps.
- *
- * Our interface (see RdfInterface) also exposes the EntityOwnerInterface.
- * This allows us to provide methods for setting and providing ownership
- * information.
- *
- * The most important part is the definitions of the field properties for this
- * entity type. These are of the same type as fields added through the GUI, but
- * they can by changed in code. In the definition we can define if the user with
- * the rights privileges can influence the presentation (view, edit) of each
- * field.
- *
- * The class also uses the EntityChangedTrait trait which allows it to record
- * timestamps of save operations.
  */
 class Rdf extends ContentEntityBase implements RdfInterface {
+
   use EntityChangedTrait;
 
   /**
@@ -190,18 +129,21 @@ class Rdf extends ContentEntityBase implements RdfInterface {
 
   /**
    * {@inheritdoc}
-   *
-   * Define the field properties here.
-   *
-   * Field name, type and size determine the table structure.
-   *
-   * In addition, we can define how the field and its content can be manipulated
-   * in the GUI. The behaviour of the widgets used can be determined here.
    */
   public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
-    // Standard field, used as unique if primary index.
-    $fields['id'] = BaseFieldDefinition::create('uri')
-      ->setLabel(t('ID'));
+    // This is the RDF unique identifier (URI) used as an unique identifier of
+    // the entity in triple store. Ideally, we have used this as ID but, because
+    // the URI happens to exceed a Drupal accepted length, it will break in core
+    // and in a lot of modules. For this reason we use this as triple store ID
+    // but we compute a shorter hash key to be used as Drupal entity ID.
+    $fields['uri'] = BaseFieldDefinition::create('uri')
+      ->setLabel(new TranslatableMarkup('URI'));
+
+    // This is the Drupal entity ID field. We compute this field as 'uri' hash.
+    $fields['id'] = BaseFieldDefinition::create('string')
+      ->setLabel(new TranslatableMarkup('ID'))
+      ->setSetting('is_ascii', TRUE)
+      ->setSetting('max_length', 48);
 
     $fields['rid'] = BaseFieldDefinition::create('entity_reference')
       ->setLabel(t('Rdf Type'))
@@ -227,7 +169,7 @@ class Rdf extends ContentEntityBase implements RdfInterface {
       ->setDisplayConfigurable('view', TRUE);
 
     // The UUID field is provided just to allow core or modules to retrieve RDF
-    // entities by UUID. In fact UUID is computed with the same value as ID.
+    // entities by UUID. In fact UUID is computed with the same value as 'uri'.
     $fields[$entity_type->getKey('uuid')] = BaseFieldDefinition::create('string')
       ->setLabel(new TranslatableMarkup('UUID'))
       ->setRevisionable(FALSE)
@@ -250,7 +192,7 @@ class Rdf extends ContentEntityBase implements RdfInterface {
    * {@inheritdoc}
    */
   public function uuid() {
-    return $this->id();
+    return $this->getUri();
   }
 
   /**
@@ -258,9 +200,10 @@ class Rdf extends ContentEntityBase implements RdfInterface {
    */
   public function createDuplicate() {
     $duplicate = parent::createDuplicate();
-    // As the ID is NULL, reset also the UUID.
+    // As the ID is NULL, reset also the UUID and the URI.
     $uuid_key = $this->getEntityType()->getKey('uuid');
     $duplicate->set($uuid_key, NULL);
+    $duplicate->set('uri', NULL);
     return $duplicate;
   }
 
@@ -321,6 +264,43 @@ class Rdf extends ContentEntityBase implements RdfInterface {
     if (!$this->isNew()) {
       $this->entityManager()->getStorage($this->entityTypeId)->deleteFromGraph($this->id(), $graph);
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUri() {
+    return $this->get('uri')->value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUri($uri) {
+    // Once set, the URI cannot be changed.
+    $current_uri = $this->getUri();
+    $is_different = $current_uri !== $uri;
+    if ($current_uri && $is_different) {
+      throw new \InvalidArgumentException('The URI of a RDF entity cannot be changed.');
+    }
+
+    if ($is_different) {
+      $this->set('uri', $uri);
+      // Sync the ID.
+      $this->set('id', $this->getUriHash($uri));
+    }
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUriHash() {
+    if (!$uri = $this->getUri()) {
+      throw new \RuntimeException('URI is not set yet.');
+    }
+    return Crypt::hashBase64($uri);
   }
 
 }

--- a/web/modules/custom/rdf_entity/src/Entity/RdfEntitySparqlStorage.php
+++ b/web/modules/custom/rdf_entity/src/Entity/RdfEntitySparqlStorage.php
@@ -317,7 +317,6 @@ WHERE{
 QUERY;
 
     $entity_values = $this->sparql->query($query);
-print_r($entity_values);
     return $this->processGraphResults($entity_values);
   }
 

--- a/web/modules/custom/rdf_entity/src/Entity/RdfEntitySparqlStorage.php
+++ b/web/modules/custom/rdf_entity/src/Entity/RdfEntitySparqlStorage.php
@@ -318,7 +318,6 @@ WHERE{
 }
 QUERY;
 
-
     // Collect URIs.
     $values = $this->sparql->query($query);
     $uris = [];
@@ -474,7 +473,7 @@ QUERY;
         }
       }
       $return[$entity_id]['uri'][LanguageInterface::LANGCODE_DEFAULT] = [
-        ['x-default' => array_flip($ids)[$entity_id]]
+        ['x-default' => array_flip($ids)[$entity_id]],
       ];
     }
 

--- a/web/modules/custom/rdf_entity/src/RdfInterface.php
+++ b/web/modules/custom/rdf_entity/src/RdfInterface.php
@@ -43,4 +43,36 @@ interface RdfInterface extends ContentEntityInterface, EntityPublishedInterface 
    */
   public function deleteFromGraph($graph);
 
+  /**
+   * Provides a setter for the 'uri' base field.
+   *
+   * @param string $uri
+   *   The URI to be set.
+   *
+   * @return $this
+   *
+   * @throws \InvalidArgumentException
+   *   If the URI is already set and different.
+   */
+  public function setUri($uri);
+
+  /**
+   * Gets the URI of th entity.
+   *
+   * @return string
+   *   The URI of th entity.
+   */
+  public function getUri();
+
+  /**
+   * Gets a hash from the URI.
+   *
+   * @return string
+   *   The hashed URI.
+   *
+   * @throws \RuntimeException
+   *   If the URI is not yet set.
+   */
+  public function getUriHash();
+
 }

--- a/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEncodingTest.php
+++ b/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEncodingTest.php
@@ -2,24 +2,15 @@
 
 namespace Drupal\Tests\rdf_entity\Kernel;
 
-use Drupal\Core\Database\Database;
-use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\rdf_entity\Entity\Rdf;
-use EasyRdf\Http;
+use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
 
 /**
  * Tests the support of saving various encoded stings in the triple store.
  *
  * @group rdf_entity
  */
-class RdfEncodingTest extends EntityKernelTestBase {
-
-  /**
-   * The SPARQL database connection.
-   *
-   * @var array
-   */
-  protected $database;
+class RdfEncodingTest extends JoinupKernelTestBase {
 
   /**
    * Modules to enable for this test.
@@ -27,13 +18,8 @@ class RdfEncodingTest extends EntityKernelTestBase {
    * @var string[]
    */
   public static $modules = array(
-    'rdf_entity',
     'rdf_entity_test',
     'field',
-    'node',
-    'system',
-    'options',
-    'entity_reference',
   );
 
   /**
@@ -42,58 +28,9 @@ class RdfEncodingTest extends EntityKernelTestBase {
   public function setUp() {
     parent::setUp();
 
-    if (!$this->setUpSparql()) {
-      $this->markTestSkipped('No Sparql connection available.');
-    }
-    // Test is not compatible with Virtuoso 6.
-    if ($this->detectVirtuoso6()) {
-      $this->markTestSkipped('Skipping: Not running on Virtuoso 6.');
-    }
-
     $this->installConfig(['rdf_entity']);
     $this->installEntitySchema('rdf_entity');
-
     $this->installConfig(['rdf_entity_test']);
-  }
-
-  /**
-   * Checks if the triple store is an Virtuoso 6 instance.
-   */
-  protected function detectVirtuoso6() {
-    $client = Http::getDefaultHttpClient();
-    $client->resetParameters(TRUE);
-    $client->setUri("http://{$this->database['host']}:{$this->database['port']}/");
-    $client->setMethod('GET');
-    $response = $client->request();
-    $server_header = $response->getHeader('Server');
-    if (strpos($server_header, "Virtuoso/06") === FALSE) {
-      return FALSE;
-    }
-    return TRUE;
-  }
-
-  /**
-   * Setup the db connection to the triple store.
-   */
-  protected function setUpSparql() {
-    // If the test is run with argument db url then use it.
-    // export SIMPLETEST_SPARQL_DB='sparql://127.0.0.1:8890/'.
-    $db_url = getenv('SIMPLETEST_SPARQL_DB');
-    if (empty($db_url)) {
-      return FALSE;
-    }
-    $this->database = Database::convertDbUrlToConnectionInfo($db_url, DRUPAL_ROOT);
-    $this->database['namespace'] = 'Drupal\\rdf_entity\\Database\\Driver\\sparql';
-    Database::addConnectionInfo('sparql_default', 'default', $this->database);
-
-    return TRUE;
-  }
-
-  /**
-   * Clear the index after every test.
-   */
-  public function tearDown() {
-    parent::tearDown();
   }
 
   /**
@@ -159,7 +96,6 @@ class RdfEncodingTest extends EntityKernelTestBase {
       $this->assertEquals($text['value'], $naughty_string, $msg);
       $rdf->delete();
     }
-
   }
 
 }

--- a/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEntityTest.php
+++ b/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEntityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\rdf_entity\Kernel;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\rdf_entity\Entity\Rdf;
+use Drupal\Tests\joinup_core\Kernel\JoinupKernelTestBase;
+
+/**
+ * Tests RDF entity.
+ *
+ * @group rdf_entity
+ */
+class RdfEntityTest extends JoinupKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'rdf_entity_test',
+    'field',
+  ];
+
+  /**
+   * Tests RDF entity CRUD.
+   */
+  public function testMain() {
+    $this->installConfig(['rdf_entity']);
+    $this->installEntitySchema('rdf_entity');
+    $this->installConfig(['rdf_entity_test']);
+
+    // Create a rdf_entity with a pre-filled URI.
+    $rdf = Rdf::create([
+      'uri' => 'http://example.com',
+      'rid' => 'dummy',
+      'label' => 'Foo',
+      'field_text' => 'Bar',
+    ]);
+    $rdf->save();
+
+    // Check that values were retrieved after loading from triple store.
+    $rdf = Rdf::load($rdf->id());
+
+//print_r($rdf->toArray());
+    $this->assertEquals('http://example.com', $rdf->getUri());
+    $this->assertEquals('http://example.com', $rdf->uuid());
+    $this->assertEquals(Crypt::hashBase64('http://example.com'), $rdf->id());
+    $this->assertEquals('dummy', $rdf->bundle());
+    $this->assertEquals('Foo', $rdf->label());
+    $this->assertEquals('Bar', $rdf->field_text->value);
+
+    // Create a rdf_entity with no initial URI.
+//    $rdf = Rdf::create([
+//      'rid' => 'dummy',
+//      'label' => 'Baz',
+//      'field_text' => 'Qux',
+//    ]);
+//    $rdf->save();
+//
+//    // Check that values were retrieved after loading from triple store.
+//    $rdf = Rdf::load($rdf->id());
+//    $this->assertEquals($rdf->getUri(), $rdf->uuid());
+//    $this->assertEquals(Crypt::hashBase64($rdf->getUri()), $rdf->id());
+//    $this->assertEquals('dummy', $rdf->bundle());
+//    $this->assertEquals('Baz', $rdf->label());
+//    $this->assertEquals('Qux', $rdf->field_text->value);
+  }
+
+}

--- a/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEntityTest.php
+++ b/web/modules/custom/rdf_entity/tests/src/Kernel/RdfEntityTest.php
@@ -41,7 +41,6 @@ class RdfEntityTest extends JoinupKernelTestBase {
     // Check that values were retrieved after loading from triple store.
     $rdf = Rdf::load($rdf->id());
 
-//print_r($rdf->toArray());
     $this->assertEquals('http://example.com', $rdf->getUri());
     $this->assertEquals('http://example.com', $rdf->uuid());
     $this->assertEquals(Crypt::hashBase64('http://example.com'), $rdf->id());
@@ -50,20 +49,20 @@ class RdfEntityTest extends JoinupKernelTestBase {
     $this->assertEquals('Bar', $rdf->field_text->value);
 
     // Create a rdf_entity with no initial URI.
-//    $rdf = Rdf::create([
-//      'rid' => 'dummy',
-//      'label' => 'Baz',
-//      'field_text' => 'Qux',
-//    ]);
-//    $rdf->save();
-//
-//    // Check that values were retrieved after loading from triple store.
-//    $rdf = Rdf::load($rdf->id());
-//    $this->assertEquals($rdf->getUri(), $rdf->uuid());
-//    $this->assertEquals(Crypt::hashBase64($rdf->getUri()), $rdf->id());
-//    $this->assertEquals('dummy', $rdf->bundle());
-//    $this->assertEquals('Baz', $rdf->label());
-//    $this->assertEquals('Qux', $rdf->field_text->value);
+    $rdf = Rdf::create([
+      'rid' => 'dummy',
+      'label' => 'Baz',
+      'field_text' => 'Qux',
+    ]);
+    $rdf->save();
+
+    // Check that values were retrieved after loading from triple store.
+    $rdf = Rdf::load($rdf->id());
+    $this->assertEquals($rdf->getUri(), $rdf->uuid());
+    $this->assertEquals(Crypt::hashBase64($rdf->getUri()), $rdf->id());
+    $this->assertEquals('dummy', $rdf->bundle());
+    $this->assertEquals('Baz', $rdf->label());
+    $this->assertEquals('Qux', $rdf->field_text->value);
   }
 
 }


### PR DESCRIPTION
## TL;DR

Assure a consistent, predictable as length, Drupal entity ID for RDF entities while still keeping the actual structure on the Virtuoso triple-store side.

## Problem

The length of the entity ID is a URI and we cannot predict its maximum length. This creates tons of problems with Drupal core and contrib modules. At the beginning, in Drupal, entities had serial IDs or short string IDs. Later, in Drupal 8, non-numeric IDs were standardised but core and modules are still influenced by the long history of _entities with numeric IDs_. Such string IDs are used in primary key and unique indexes but MySQL has a length limitation on the string indexed columns. The index cannot exceed 767 bytes that meaning such columns should fit 255 characters. But with the real data we have URIs exceeding this limitation. This is creating issues, at least in `{file_usage}`, dedicated table fields and `{cachetags}` tables (Drupal core), `{search_api_item}` table (Search API). But it's expected that this issue will surface on each functionality that is storing references to such entities.

## Concept (very rough):

- In Drupal, switch the ID from the URI to a hash of the URI which offers enough unicity but is limited to 48 ASCII characters. Should be computed as `Crypt::hashBase64(<ACTUAL URI>)`.
- On triple-store side, the new ID field will be stored and mapped as `http://purl.org/dc/terms/identifier`.
- The URI will be still kept as subject of the triple.
- The RDF storage and entity query will be reworked to use `http://purl.org/dc/terms/identifier` when querying by ID.
- Create a new type of field `rdf_entity_reference` by extending `EntityReferenceItem` that is only adding a new column `target_uri` along with the existing `target_id`. Map this new column to the values used until now by `target_id`. Make this column automatically receive the `uri` field of the target entity.
- @todo: Check impact on Solr & Views. Should not be out of control. ID is still a string.