### PR TITLE
Revert "ISAICP-2369: Enable taking screenshots when a test fails in B…

### DIFF
--- a/tests/behat.yml.dist
+++ b/tests/behat.yml.dist
@@ -4,7 +4,6 @@ default:
       contexts:
         - FeatureContext
         - Drupal\joinup\Context\DrupalContext
-        - Drupal\joinup\Context\ScreenshotContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MinkContext


### PR DESCRIPTION
…ehat."

Current code causes original exceptions to be hidden when no page
requests have been made yet.

This reverts commit 4ada78c70cb82c18e97b6dbf098a18ebda2c533f.