### PR TITLE
Revert 3234 (views > tables)

### DIFF
--- a/build.migration.xml
+++ b/build.migration.xml
@@ -8,6 +8,15 @@
             depends="enable-migration-modules">
         <echo message="Running migration IDs" />
         <drush
+             command="cset"
+             assume="yes"
+             root="${website.drupal.dir}"
+             bin="${drush.bin}"
+             verbose="${drush.verbose}">
+            <param>search_api.index.collections</param>
+            <param>options.index_directly 0</param>
+        </drush>
+        <drush
             command="migrate-import"
             assume="yes"
             root="${website.drupal.dir}"
@@ -16,6 +25,22 @@
             <param>${migration.ids}</param>
             <option name="feedback" value="1000" />
             <option name="force" />
+        </drush>
+        <drush
+            command="cfr"
+            assume="yes"
+            root="${website.drupal.dir}"
+            bin="${drush.bin}"
+            verbose="${drush.verbose}">
+            <param>search_api.index.collections</param>
+        </drush>
+        <drush
+                command="sapi-i"
+                assume="yes"
+                root="${website.drupal.dir}"
+                bin="${drush.bin}"
+                verbose="${drush.verbose}">
+            <option name="batch-size" value="500" />
         </drush>
         <drush
             command="migrate-report-generate"

--- a/build.migration.xml
+++ b/build.migration.xml
@@ -8,15 +8,6 @@
             depends="enable-migration-modules">
         <echo message="Running migration IDs" />
         <drush
-             command="cset"
-             assume="yes"
-             root="${website.drupal.dir}"
-             bin="${drush.bin}"
-             verbose="${drush.verbose}">
-            <param>search_api.index.collections</param>
-            <param>options.index_directly 0</param>
-        </drush>
-        <drush
             command="migrate-import"
             assume="yes"
             root="${website.drupal.dir}"
@@ -25,22 +16,6 @@
             <param>${migration.ids}</param>
             <option name="feedback" value="1000" />
             <option name="force" />
-        </drush>
-        <drush
-            command="cfr"
-            assume="yes"
-            root="${website.drupal.dir}"
-            bin="${drush.bin}"
-            verbose="${drush.verbose}">
-            <param>search_api.index.collections</param>
-        </drush>
-        <drush
-                command="sapi-i"
-                assume="yes"
-                root="${website.drupal.dir}"
-                bin="${drush.bin}"
-                verbose="${drush.verbose}">
-            <option name="batch-size" value="500" />
         </drush>
         <drush
             command="migrate-report-generate"

--- a/web/modules/custom/joinup_migrate/fixture/1.contact.sql
+++ b/web/modules/custom/joinup_migrate/fixture/1.contact.sql
@@ -1,59 +1,51 @@
-CREATE TABLE IF NOT EXISTS d8_contact (
-  nid INT,
-  vid INT,
-  title VARCHAR(255),
-  uri LONGTEXT,
-  created_time VARCHAR(24),
-  changed_time VARCHAR(24),
-  uid INT,
-  mail LONGTEXT,
-  webpage LONGTEXT,
-  collection VARCHAR(255),
-  solution INT
-) AS SELECT n.nid AS nid,
-            n.vid AS vid,
-            n.title AS title,
-            TRIM(uri.field_id_uri_value) AS uri,
-            FROM_UNIXTIME(n.created, '%Y-%m-%dT%H:%i:%s') AS created_time,
-            FROM_UNIXTIME(n.changed, '%Y-%m-%dT%H:%i:%s') AS changed_time,
-            n.uid AS uid,
-            cfcpm.field_contact_point_mail_value AS mail,
-            cfcpwp.field_contact_point_web_page_url AS webpage,
-            c.collection AS collection,
-            NULL AS solution FROM
-       d8_collection c
-       INNER JOIN
-       node n ON FIND_IN_SET(n.nid, c.contact)
-       LEFT JOIN
-       content_field_id_uri uri ON n.vid = uri.vid
-       LEFT JOIN
-       content_field_contact_point_mail cfcpm ON n.vid = cfcpm.vid
-       LEFT JOIN
-       content_field_contact_point_web_page cfcpwp ON n.vid = cfcpwp.vid
-     UNION SELECT
-             n2.nid,
-             n2.vid,
-             n2.title,
-             TRIM(uri2.field_id_uri_value),
-             FROM_UNIXTIME(n2.created, '%Y-%m-%dT%H:%i:%s'),
-             FROM_UNIXTIME(n2.changed, '%Y-%m-%dT%H:%i:%s'),
-             n2.uid,
-             cfcpm2.field_contact_point_mail_value,
-             cfcpwp2.field_contact_point_web_page_url,
-             NULL,
-             s.nid
-           FROM
-             d8_solution s
-             INNER JOIN
-             content_type_asset_release ctar ON s.vid = ctar.vid
-             INNER JOIN
-             node n2 ON ctar.field_asset_contact_point_nid = n2.nid
-             LEFT JOIN
-             content_field_id_uri uri2 ON n2.vid = uri2.vid
-             LEFT JOIN
-             content_field_contact_point_mail cfcpm2 ON n2.vid = cfcpm2.vid
-             LEFT JOIN
-             content_field_contact_point_web_page cfcpwp2 ON n2.vid = cfcpwp2.vid
-           WHERE
-             n2.type = 'contact_point'
-     ORDER BY nid
+CREATE OR REPLACE VIEW d8_contact (
+  nid,
+  vid,
+  title,
+  uri,
+  created_time,
+  changed_time,
+  uid,
+  mail,
+  webpage,
+  collection,
+  solution
+) AS
+SELECT
+  n.nid,
+  n.vid,
+  n.title,
+  TRIM(uri.field_id_uri_value),
+  FROM_UNIXTIME(n.created, '%Y-%m-%dT%H:%i:%s'),
+  FROM_UNIXTIME(n.changed, '%Y-%m-%dT%H:%i:%s'),
+  n.uid,
+  cfcpm.field_contact_point_mail_value,
+  cfcpwp.field_contact_point_web_page_url,
+  c.collection,
+  NULL
+FROM d8_collection c
+INNER JOIN node n ON FIND_IN_SET(n.nid, c.contact)
+LEFT JOIN content_field_id_uri uri ON n.vid = uri.vid
+LEFT JOIN content_field_contact_point_mail cfcpm ON n.vid = cfcpm.vid
+LEFT JOIN content_field_contact_point_web_page cfcpwp ON n.vid = cfcpwp.vid
+UNION
+SELECT
+  n2.nid,
+  n2.vid,
+  n2.title,
+  TRIM(uri2.field_id_uri_value),
+  FROM_UNIXTIME(n2.created, '%Y-%m-%dT%H:%i:%s'),
+  FROM_UNIXTIME(n2.changed, '%Y-%m-%dT%H:%i:%s'),
+  n2.uid,
+  cfcpm2.field_contact_point_mail_value,
+  cfcpwp2.field_contact_point_web_page_url,
+  NULL,
+  s.nid
+FROM d8_solution s
+INNER JOIN content_type_asset_release ctar ON s.vid = ctar.vid
+INNER JOIN node n2 ON ctar.field_asset_contact_point_nid = n2.nid
+LEFT JOIN content_field_id_uri uri2 ON n2.vid = uri2.vid
+LEFT JOIN content_field_contact_point_mail cfcpm2 ON n2.vid = cfcpm2.vid
+LEFT JOIN content_field_contact_point_web_page cfcpwp2 ON n2.vid = cfcpwp2.vid
+WHERE n2.type = 'contact_point'
+ORDER BY nid

--- a/web/modules/custom/joinup_migrate/fixture/1.contact_solution.sql
+++ b/web/modules/custom/joinup_migrate/fixture/1.contact_solution.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE VIEW d8_contact_solution (
+  nid,
+  vid,
+  title,
+  uri,
+  created_time,
+  changed_time,
+  uid,
+  mail,
+  webpage,
+  solution
+) AS
+SELECT
+  n2.nid,
+  n2.vid,
+  n2.title,
+  TRIM(uri2.field_id_uri_value),
+  FROM_UNIXTIME(n2.created, '%Y-%m-%dT%H:%i:%s'),
+  FROM_UNIXTIME(n2.changed, '%Y-%m-%dT%H:%i:%s'),
+  n2.uid,
+  cfcpm2.field_contact_point_mail_value,
+  cfcpwp2.field_contact_point_web_page_url,
+  s.nid
+FROM d8_solution s
+INNER JOIN content_type_asset_release ctar ON s.vid = ctar.vid
+INNER JOIN node n2 ON ctar.field_asset_contact_point_nid = n2.nid
+LEFT JOIN content_field_id_uri uri2 ON n2.vid = uri2.vid
+LEFT JOIN content_field_contact_point_mail cfcpm2 ON n2.vid = cfcpm2.vid
+LEFT JOIN content_field_contact_point_web_page cfcpwp2 ON n2.vid = cfcpwp2.vid
+WHERE n2.type = 'contact_point'
+ORDER BY n2.nid

--- a/web/modules/custom/joinup_migrate/fixture/1.owner.sql
+++ b/web/modules/custom/joinup_migrate/fixture/1.owner.sql
@@ -1,41 +1,35 @@
-# DROP VIEW IF EXISTS d8_owner;
-# DROP TABLE IF EXISTS d8_owner;
-CREATE TABLE IF NOT EXISTS d8_owner (
-    nid INT NOT NULL,
-    vid INT NOT NULL,
-    title VARCHAR(255),
-    uri LONGTEXT,
-    uid INT,
-    collection VARCHAR(255),
-    solution INT
-) AS SELECT n.nid AS nid,
-            n.vid AS vid,
-            n.title AS title,
-            TRIM(uri.field_id_uri_value) AS uri,
-            n.uid AS uid,
-            c.collection AS collection,
-            NULL AS solution FROM
-         d8_collection c
-         INNER JOIN
-         node n ON FIND_IN_SET(n.nid, c.owner)
-         LEFT JOIN
-         content_field_id_uri uri ON n.vid = uri.vid
-     UNION SELECT
-               n2.nid,
-               n2.vid,
-               n2.title,
-               TRIM(uri2.field_id_uri_value),
-               n2.uid,
-               NULL,
-               s.nid
-           FROM
-               d8_solution s
-               INNER JOIN
-               content_field_asset_publisher cfap ON s.vid = cfap.vid
-               INNER JOIN
-               node n2 ON cfap.field_asset_publisher_nid = n2.nid
-               LEFT JOIN
-               content_field_id_uri uri2 ON n2.vid = uri2.vid
-           WHERE
-               n2.type = 'publisher'
-     ORDER BY nid
+CREATE OR REPLACE VIEW d8_owner (
+  nid,
+  vid,
+  title,
+  uri,
+  uid,
+  collection,
+  solution
+) AS
+SELECT
+  n.nid,
+  n.vid,
+  n.title,
+  TRIM(uri.field_id_uri_value),
+  n.uid,
+  c.collection,
+  NULL
+FROM d8_collection c
+INNER JOIN node n ON FIND_IN_SET(n.nid, c.owner)
+LEFT JOIN content_field_id_uri uri ON n.vid = uri.vid
+UNION
+SELECT
+  n2.nid,
+  n2.vid,
+  n2.title,
+  TRIM(uri2.field_id_uri_value),
+  n2.uid,
+  NULL,
+  s.nid
+FROM d8_solution s
+INNER JOIN content_field_asset_publisher cfap ON s.vid = cfap.vid
+INNER JOIN node n2 ON cfap.field_asset_publisher_nid = n2.nid
+LEFT JOIN content_field_id_uri uri2 ON n2.vid = uri2.vid
+WHERE n2.type = 'publisher'
+ORDER BY nid

--- a/web/modules/custom/joinup_migrate/fixture/1.owner.sql
+++ b/web/modules/custom/joinup_migrate/fixture/1.owner.sql
@@ -1,3 +1,5 @@
+# DROP VIEW IF EXISTS d8_owner;
+# DROP TABLE IF EXISTS d8_owner;
 CREATE TABLE IF NOT EXISTS d8_owner (
     nid INT NOT NULL,
     vid INT NOT NULL,

--- a/web/modules/custom/joinup_migrate/fixture/1.owner_solution.sql
+++ b/web/modules/custom/joinup_migrate/fixture/1.owner_solution.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW d8_owner_solution (
+  nid,
+  vid,
+  title,
+  uri,
+  uid,
+  solution
+) AS
+SELECT
+  n2.nid,
+  n2.vid,
+  n2.title,
+  TRIM(uri2.field_id_uri_value),
+  n2.uid,
+  s.nid
+FROM d8_solution s
+INNER JOIN content_field_asset_publisher cfap ON s.vid = cfap.vid
+INNER JOIN node n2 ON cfap.field_asset_publisher_nid = n2.nid
+LEFT JOIN content_field_id_uri uri2 ON n2.vid = uri2.vid
+WHERE n2.type = 'publisher'
+ORDER BY n2.nid

--- a/web/modules/custom/joinup_migrate/joinup_migrate.install
+++ b/web/modules/custom/joinup_migrate/joinup_migrate.install
@@ -28,9 +28,6 @@ function joinup_migrate_install() {
   // be installed before 1.*.sql.
   ksort($views);
   foreach ($views as $view) {
-    $name = 'd8_' . Unicode::substr($view->name, 2);
-    $db->query("DROP VIEW IF EXISTS $name")->execute();
-    $db->query("DROP TABLE IF EXISTS $name")->execute();
     $db->query(file_get_contents($view->uri))->execute();
   }
 

--- a/web/modules/custom/joinup_migrate/src/Plugin/migrate/source/Solution.php
+++ b/web/modules/custom/joinup_migrate/src/Plugin/migrate/source/Solution.php
@@ -89,7 +89,7 @@ class Solution extends SolutionBase {
     $row->setSourceProperty('country', $this->getCountries([$vid]));
 
     // Owners.
-    $owner = $this->select('d8_owner', 'o')
+    $owner = $this->select('d8_owner_solution', 'o')
       ->fields('o', ['nid'])
       ->condition('o.solution', $nid)
       ->execute()
@@ -97,7 +97,7 @@ class Solution extends SolutionBase {
     $row->setSourceProperty('owner', $owner);
 
     // Contacts.
-    $contact = $this->select('d8_contact', 'c')
+    $contact = $this->select('d8_contact_solution', 'c')
       ->fields('c', ['nid'])
       ->condition('c.solution', $nid)
       ->execute()


### PR DESCRIPTION
On a new install I enabled the `joinup_migrate` module. Then, looking into the new tables `d8_contact` and `d8_owner`, I see them both empty. And this is logic because they are both based on view `d8_solution`. And that is a view based on other migrations that were not run yet.

**Solution**: Use different, lightweight, views for `solution` migration.