### PR TITLE
Builds fail because of mail being sent before it is redirected

### DIFF
--- a/build.project.xml
+++ b/build.project.xml
@@ -208,41 +208,4 @@
         description="Install the website and set up the development environment."
         depends="setup-virtuoso-permissions, purge-rdf-backend, install, import-rdf-fixtures, setup-dev, configure-apache-solr-drupal, create-demo-users" />
 
-    <!-- Overrides "redirect-outgoing-email" from build.dist.xml -->
-    <target name="redirect-outgoing-email">
-        <reflexive>
-            <fileset dir="${website.settings.dir}">
-                <include pattern="settings.local.php" />
-            </fileset>
-            <filterchain>
-                <replaceregexp>
-                    <regexp
-                        pattern="(\n)?\$config\['system.mail'\]\['interface'\]\['default'\] = 'devel_mail_log';(\n)?"
-                        replace="" />
-                    <regexp
-                        pattern="(\n)?\$config\['mailsystem.settings'\]\['defaults'\]\['sender'\] = 'devel_mail_log';(\n)?"
-                        replace="${line.separator}"
-                        modifiers="" />
-                </replaceregexp>
-            </filterchain>
-        </reflexive>
-        <if>
-            <equals arg1="${drupal.redirect.email}" arg2="yes" />
-            <then>
-                <phingcall target="enable-module">
-                    <property name="module" value="devel" />
-                </phingcall>
-                <append
-                    destFile="${website.settings.local.php}"
-                    text="${line.separator}$config['system.mail']['interface']['default'] = 'devel_mail_log';${line.separator}" />
-                <append
-                    destFile="${website.settings.local.php}"
-                    text="$config['mailsystem.settings']['defaults']['sender'] = 'devel_mail_log';${line.separator}" />
-            </then>
-            <else>
-                <echo message="Skipping redirection of outgoing e-mail. Set 'drupal.redirect.email = yes' to enable." />
-            </else>
-        </if>
-    </target>
-
 </project>


### PR DESCRIPTION
The fix is to swap `redirect-outgoing-email` and `enable-dev-modules` since there is mail being sent while the dev modules are being enabled.

Our improved `redirect-outgoing-email` target has been contributed upstream to the drupal-project fork and merged back down.