### PR TITLE
ISAICP-3519: Do not send a role change email if the membership is new…

### DIFF
--- a/web/modules/custom/joinup_notification/src/EventSubscriber/OgMembershipSubscriber.php
+++ b/web/modules/custom/joinup_notification/src/EventSubscriber/OgMembershipSubscriber.php
@@ -203,7 +203,7 @@ class OgMembershipSubscriber extends NotificationSubscriberBase implements Event
     $arguments = parent::generateArguments($message);
     $actor_first_name = $arguments['@actor:field_user_first_name'];
     $actor_last_name = $arguments['@actor:field_user_family_name'];
-    $arguments['@actor:full_name'] = $actor_first_name . ' ' . $actor_last_name;
+    $arguments['@actor:full_name'] = (empty($actor_first_name) && empty($actor_last_name)) ? 'a Joinup user' : $actor_first_name . ' ' . $actor_last_name;
 
     // Calculate extra arguments per case.
     switch ($this->operation) {

--- a/web/modules/custom/joinup_user/joinup_user.module
+++ b/web/modules/custom/joinup_user/joinup_user.module
@@ -443,6 +443,18 @@ function joinup_user_entity_base_field_info(EntityTypeInterface $entity_type) {
 function joinup_user_og_membership_presave(OgMembershipInterface $entity) {
   joinup_user_invalidate_user_cache_tags($entity);
 
+  if ($entity->isNew()) {
+    return;
+  }
+
+  /** @var \Drupal\og\OgMembershipInterface $original_membership */
+  $original_membership = $entity->original;
+  // Do not send a notification about changes in the membership if the roles did
+  // not change.
+  if ($entity->getRolesIds() === $original_membership->getRolesIds()) {
+    return;
+  }
+
   /** @var \Drupal\user\Entity\User $account */
   $account = $entity->getUser();
 


### PR DESCRIPTION
… or the roles did not change.