### PR TITLE
Hotfix to support migration database when restoring from the producti…

### DIFF
--- a/build.project.xml
+++ b/build.project.xml
@@ -366,7 +366,7 @@
     <target
         name="setup-acceptance"
         description="Set up an acceptance environment."
-        depends="setup-virtuoso-permissions, configure-apache-solr-drupal, configure-piwik-drupal, download-databases, rebuild-environment, reindex-apache-solr, enable-uat-modules, enable-dev-settings" />
+        depends="setup-virtuoso-permissions, configure-apache-solr-drupal, configure-piwik-drupal, setup-migration, import-legacy-db, download-databases, rebuild-environment, reindex-apache-solr, enable-uat-modules, enable-dev-settings" />
 
     <target
         name="install-dev"


### PR DESCRIPTION
We try to restore the production databases in the acceptance environment so the execute-migration target does not run. Thus, we need to manually run the setup-migration and import-legacy-db targets.