### PR TITLE
Clarify the method that retrieves the parent's eLibrary creation option

### DIFF
--- a/web/modules/custom/joinup_core/src/Guard/NodeGuard.php
+++ b/web/modules/custom/joinup_core/src/Guard/NodeGuard.php
@@ -121,7 +121,7 @@ class NodeGuard implements GuardInterface {
   public function allowedCreate(WorkflowTransition $transition, WorkflowInterface $workflow, EntityInterface $entity) {
     $permission_scheme = $this->permissionScheme->get('create');
     $workflow_id = $workflow->getId();
-    $e_library = $this->relationManager->getParentElibrary($entity);
+    $e_library = (string) $this->relationManager->getParentELibraryCreationOption($entity);
 
     if (!isset($permission_scheme[$workflow_id][$e_library][$transition->getId()])) {
       return FALSE;

--- a/web/modules/custom/joinup_core/src/JoinupRelationManager.php
+++ b/web/modules/custom/joinup_core/src/JoinupRelationManager.php
@@ -98,14 +98,15 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getParentElibrary(EntityInterface $entity) {
+  // @codingStandardsIgnoreLine
+  public function getParentELibraryCreationOption(EntityInterface $entity): int {
     $parent = $this->getParent($entity);
     $field_array = [
       'collection' => 'field_ar_elibrary_creation',
       'solution' => 'field_is_elibrary_creation',
     ];
 
-    $e_library = $parent->{$field_array[$parent->bundle()]}->first()->value;
+    $e_library = (int) $parent->{$field_array[$parent->bundle()]}->first()->value;
     return $e_library;
   }
 

--- a/web/modules/custom/joinup_core/src/JoinupRelationManagerInterface.php
+++ b/web/modules/custom/joinup_core/src/JoinupRelationManagerInterface.php
@@ -46,15 +46,19 @@ interface JoinupRelationManagerInterface {
   public function getParentState(EntityInterface $entity);
 
   /**
-   * Retrieves the eLibrary settings of the parent.
+   * Retrieves the eLibrary creation option of the parent.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The group content entity.
    *
-   * @return string
-   *   The state of the parent entity.
+   * @return int
+   *   The eLibrary creation option. Can be one of the following values:
+   *   - \Drupal\joinup_core\ELibraryCreationOptions::FACILITATORS
+   *   - \Drupal\joinup_core\ELibraryCreationOptions::MEMBERS
+   *   - \Drupal\joinup_core\ELibraryCreationOptions::REGISTERED_USERS
    */
-  public function getParentElibrary(EntityInterface $entity);
+  // @codingStandardsIgnoreLine
+  public function getParentELibraryCreationOption(EntityInterface $entity): int;
 
   /**
    * Retrieves all the users that have the administrator role in a group.

--- a/web/modules/custom/joinup_core/src/ProxyClass/JoinupRelationManager.php
+++ b/web/modules/custom/joinup_core/src/ProxyClass/JoinupRelationManager.php
@@ -102,9 +102,9 @@ namespace Drupal\joinup_core\ProxyClass {
         /**
          * {@inheritdoc}
          */
-        public function getParentElibrary(\Drupal\Core\Entity\EntityInterface $entity)
+        public function getParentELibraryCreationOption(\Drupal\Core\Entity\EntityInterface $entity) : int
         {
-            return $this->lazyLoadItself()->getParentElibrary($entity);
+            return $this->lazyLoadItself()->getParentELibraryCreationOption($entity);
         }
 
         /**


### PR DESCRIPTION
I encountered this method during my work on ISAICP-4498 and it confused my brains. The documentation did not help to unconfuse. So let's fix.