### PR TITLE
Clean up the JoinupRelationManager service

### DIFF
--- a/web/modules/custom/joinup_community_content/joinup_community_content.module
+++ b/web/modules/custom/joinup_community_content/joinup_community_content.module
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
 use Drupal\joinup_community_content\CommunityContentHelper;
+use Drupal\joinup_core\NodeWorkflowAccessControlHandler;
 
 /**
  * Implements hook_entity_extra_field_info().
@@ -128,10 +129,10 @@ function joinup_community_content_workflow_selector(EntityInterface $entity) {
     throw new Exception('This function can only be called for community content apart from discussion.');
   }
 
-  /** @var \Drupal\joinup_core\JoinupRelationManager $relation_manager */
+  /** @var \Drupal\joinup_core\JoinupRelationManagerInterface $relation_manager */
   $relation_manager = \Drupal::service('joinup_core.relations_manager');
   $moderation = $relation_manager->getParentModeration($entity);
-  return $moderation == 1 ? 'node:pre_moderated' : 'node:post_moderated';
+  return $moderation == NodeWorkflowAccessControlHandler::PRE_MODERATION ? 'node:pre_moderated' : 'node:post_moderated';
 }
 
 /**

--- a/web/modules/custom/joinup_core/src/JoinupRelationManager.php
+++ b/web/modules/custom/joinup_core/src/JoinupRelationManager.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\joinup_core;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
@@ -8,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\MembershipManagerInterface;
 use Drupal\og\OgMembershipInterface;
+use Drupal\rdf_entity\RdfInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -55,7 +58,7 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getParent(EntityInterface $entity) {
+  public function getParent(EntityInterface $entity): ?RdfInterface {
     $groups = $this->membershipManager->getGroups($entity);
     if (empty($groups['rdf_entity'])) {
       return NULL;
@@ -67,7 +70,7 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getParentModeration(EntityInterface $entity) {
+  public function getParentModeration(EntityInterface $entity): ?int {
     $parent = $this->getParent($entity);
     if (!$parent) {
       return NULL;
@@ -78,13 +81,13 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
     ];
 
     $moderation = $parent->{$field_array[$parent->bundle()]}->value;
-    return $moderation;
+    return (int) $moderation;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getParentState(EntityInterface $entity) {
+  public function getParentState(EntityInterface $entity): string {
     $parent = $this->getParent($entity);
     $field_array = [
       'collection' => 'field_ar_state',
@@ -113,11 +116,11 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getGroupOwners(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getGroupOwners(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array {
     $role_id = $entity->getEntityTypeId() . '-' . $entity->bundle() . '-administrator';
 
     $users = [];
-    foreach ($this->getGroupMemberships($entity, $state) as $membership) {
+    foreach ($this->getGroupMemberships($entity, $states) as $membership) {
       $user = $membership->getOwner();
       if (!empty($user) && $membership->hasRole($role_id)) {
         $users[$user->id()] = $user;
@@ -130,8 +133,8 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getGroupUsers(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]) {
-    return array_reduce($this->getGroupMemberships($entity, $state), function ($users, OgMembershipInterface $membership) {
+  public function getGroupUsers(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array {
+    return array_reduce($this->getGroupMemberships($entity, $states), function ($users, OgMembershipInterface $membership) {
       $user = $membership->getOwner();
       if (!empty($user)) {
         $users[] = $user;
@@ -143,10 +146,10 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getGroupMemberships(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getGroupMemberships(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array {
     /** @var \Drupal\og\OgMembershipInterface[] $memberships */
     $memberships = $this->entityTypeManager->getStorage('og_membership')->loadByProperties([
-      'state' => $state,
+      'state' => $states,
       'entity_type' => $entity->getEntityTypeId(),
       'entity_id' => $entity->id(),
     ]);
@@ -157,14 +160,14 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getUserMembershipsByRole(AccountInterface $user, $role, array $state = [OgMembershipInterface::STATE_ACTIVE]) {
+  public function getUserMembershipsByRole(AccountInterface $user, string $role, array $states = [OgMembershipInterface::STATE_ACTIVE]): array {
     $storage = $this->entityTypeManager->getStorage('og_membership');
 
     // Fetch all the memberships of the user, filtered by role and state.
     $query = $storage->getQuery();
     $query->condition('uid', $user->id());
     $query->condition('roles', $role);
-    $query->condition('state', $state, 'IN');
+    $query->condition('state', $states, 'IN');
     $result = $query->execute();
 
     return $storage->loadMultiple($result);
@@ -173,7 +176,7 @@ class JoinupRelationManager implements JoinupRelationManagerInterface, Container
   /**
    * {@inheritdoc}
    */
-  public function getCollectionsWhereSoleOwner(AccountInterface $user) {
+  public function getCollectionsWhereSoleOwner(AccountInterface $user): array {
     $memberships = $this->getUserMembershipsByRole($user, 'rdf_entity-collection-administrator');
 
     // Prepare a list of collections where the user is the sole owner.

--- a/web/modules/custom/joinup_core/src/JoinupRelationManagerInterface.php
+++ b/web/modules/custom/joinup_core/src/JoinupRelationManagerInterface.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\joinup_core;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\og\OgMembershipInterface;
+use Drupal\rdf_entity\RdfInterface;
 
 /**
  * An interface for Joinup relation manager services.
@@ -21,7 +24,7 @@ interface JoinupRelationManagerInterface {
    *   The rdf entity the passed entity belongs to, or NULL when no group is
    *    found.
    */
-  public function getParent(EntityInterface $entity);
+  public function getParent(EntityInterface $entity): ?RdfInterface;
 
   /**
    * Retrieves the moderation state of the parent.
@@ -30,9 +33,11 @@ interface JoinupRelationManagerInterface {
    *   The group content entity.
    *
    * @return int
-   *   The moderation status.
+   *   The moderation status. Can be one of the following values:
+   *   - NodeWorkflowAccessControlHandler::PRE_MODERATION
+   *   - NodeWorkflowAccessControlHandler::POST_MODERATION
    */
-  public function getParentModeration(EntityInterface $entity);
+  public function getParentModeration(EntityInterface $entity): ?int;
 
   /**
    * Retrieves the state of the parent.
@@ -43,7 +48,7 @@ interface JoinupRelationManagerInterface {
    * @return string
    *   The state of the parent entity.
    */
-  public function getParentState(EntityInterface $entity);
+  public function getParentState(EntityInterface $entity): string;
 
   /**
    * Retrieves the eLibrary creation option of the parent.
@@ -65,39 +70,39 @@ interface JoinupRelationManagerInterface {
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The group entity.
-   * @param array $state
+   * @param array $states
    *   (optional) An array of membership states to retrieve. Defaults to active.
    *
    * @return array
    *   An array of users that are administrators of the entity group.
    */
-  public function getGroupOwners(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getGroupOwners(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array;
 
   /**
    * Retrieves all the members with any role in a certain group.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The group entity.
-   * @param array $state
+   * @param array $states
    *   (optional) An array of membership states to retrieve. Defaults to active.
    *
    * @return array
    *   An array of users that are members of the entity group.
    */
-  public function getGroupUsers(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getGroupUsers(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array;
 
   /**
    * Retrieves all the memberships of a certain entity group.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The group entity.
-   * @param array $state
+   * @param array $states
    *   (optional) An array of membership states to retrieve. Defaults to active.
    *
    * @return \Drupal\og\OgMembershipInterface[]
    *   The memberships of the group.
    */
-  public function getGroupMemberships(EntityInterface $entity, array $state = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getGroupMemberships(EntityInterface $entity, array $states = [OgMembershipInterface::STATE_ACTIVE]): array;
 
   /**
    * Retrieves all the user memberships with a certain role and state.
@@ -106,13 +111,13 @@ interface JoinupRelationManagerInterface {
    *   The user to get the memberships for.
    * @param string $role
    *   The role id.
-   * @param array $state
+   * @param array $states
    *   (optional) An array of membership states to retrieve. Defaults to active.
    *
    * @return \Drupal\og\OgMembershipInterface[]
    *   An array of OG memberships that match the criteria.
    */
-  public function getUserMembershipsByRole(AccountInterface $user, $role, array $state = [OgMembershipInterface::STATE_ACTIVE]);
+  public function getUserMembershipsByRole(AccountInterface $user, string $role, array $states = [OgMembershipInterface::STATE_ACTIVE]): array;
 
   /**
    * Retrieves all the collections where a user is the sole owner.
@@ -123,6 +128,6 @@ interface JoinupRelationManagerInterface {
    * @return \Drupal\rdf_entity\Entity\Rdf[]
    *   An array of collections.
    */
-  public function getCollectionsWhereSoleOwner(AccountInterface $user);
+  public function getCollectionsWhereSoleOwner(AccountInterface $user): array;
 
 }

--- a/web/modules/custom/joinup_core/src/ProxyClass/JoinupRelationManager.php
+++ b/web/modules/custom/joinup_core/src/ProxyClass/JoinupRelationManager.php
@@ -78,7 +78,7 @@ namespace Drupal\joinup_core\ProxyClass {
         /**
          * {@inheritdoc}
          */
-        public function getParent(\Drupal\Core\Entity\EntityInterface $entity)
+        public function getParent(\Drupal\Core\Entity\EntityInterface $entity) : ?\Drupal\rdf_entity\RdfInterface
         {
             return $this->lazyLoadItself()->getParent($entity);
         }
@@ -86,7 +86,7 @@ namespace Drupal\joinup_core\ProxyClass {
         /**
          * {@inheritdoc}
          */
-        public function getParentModeration(\Drupal\Core\Entity\EntityInterface $entity)
+        public function getParentModeration(\Drupal\Core\Entity\EntityInterface $entity) : ?int
         {
             return $this->lazyLoadItself()->getParentModeration($entity);
         }
@@ -94,7 +94,7 @@ namespace Drupal\joinup_core\ProxyClass {
         /**
          * {@inheritdoc}
          */
-        public function getParentState(\Drupal\Core\Entity\EntityInterface $entity)
+        public function getParentState(\Drupal\Core\Entity\EntityInterface $entity) : string
         {
             return $this->lazyLoadItself()->getParentState($entity);
         }
@@ -110,47 +110,47 @@ namespace Drupal\joinup_core\ProxyClass {
         /**
          * {@inheritdoc}
          */
-        public function getGroupOwners(\Drupal\Core\Entity\EntityInterface $entity, array $state = array (
+        public function getGroupOwners(\Drupal\Core\Entity\EntityInterface $entity, array $states = array (
           0 => 'active',
-        ))
+        )) : array
         {
-            return $this->lazyLoadItself()->getGroupOwners($entity, $state);
+            return $this->lazyLoadItself()->getGroupOwners($entity, $states);
         }
 
         /**
          * {@inheritdoc}
          */
-        public function getGroupUsers(\Drupal\Core\Entity\EntityInterface $entity, array $state = array (
+        public function getGroupUsers(\Drupal\Core\Entity\EntityInterface $entity, array $states = array (
           0 => 'active',
-        ))
+        )) : array
         {
-            return $this->lazyLoadItself()->getGroupUsers($entity, $state);
+            return $this->lazyLoadItself()->getGroupUsers($entity, $states);
         }
 
         /**
          * {@inheritdoc}
          */
-        public function getGroupMemberships(\Drupal\Core\Entity\EntityInterface $entity, array $state = array (
+        public function getGroupMemberships(\Drupal\Core\Entity\EntityInterface $entity, array $states = array (
           0 => 'active',
-        ))
+        )) : array
         {
-            return $this->lazyLoadItself()->getGroupMemberships($entity, $state);
+            return $this->lazyLoadItself()->getGroupMemberships($entity, $states);
         }
 
         /**
          * {@inheritdoc}
          */
-        public function getUserMembershipsByRole(\Drupal\Core\Session\AccountInterface $user, $role, array $state = array (
+        public function getUserMembershipsByRole(\Drupal\Core\Session\AccountInterface $user, string $role, array $states = array (
           0 => 'active',
-        ))
+        )) : array
         {
-            return $this->lazyLoadItself()->getUserMembershipsByRole($user, $role, $state);
+            return $this->lazyLoadItself()->getUserMembershipsByRole($user, $role, $states);
         }
 
         /**
          * {@inheritdoc}
          */
-        public function getCollectionsWhereSoleOwner(\Drupal\Core\Session\AccountInterface $user)
+        public function getCollectionsWhereSoleOwner(\Drupal\Core\Session\AccountInterface $user) : array
         {
             return $this->lazyLoadItself()->getCollectionsWhereSoleOwner($user);
         }


### PR DESCRIPTION
This has been split off from ISAICP-4498. It cleans up the `JoinupRelationManager` service:

* Use strict typing.
* Return type hinting.
* Use plural argument names for array types.
* Use a constant instead of a magic number.
* Small documentation fixes.
* Type hint on the interface rather than the object.