### PR TITLE
Remove obsolete Phing target.

### DIFF
--- a/build.project.xml
+++ b/build.project.xml
@@ -236,16 +236,6 @@
         </drush>
     </target>
 
-    <target name="purge-rdf-content">
-        <drush
-            command="rdf-entity-purge"
-            assume="yes"
-            root="${website.drupal.dir}"
-            bin="${drush.bin}"
-            verbose="${drush.verbose}">
-        </drush>
-    </target>
-
     <target name="clear-cache">
         <drush
                 command="cr"


### PR DESCRIPTION
When I try to execute the `purge-rdf-content` Phing target I get an error:

```
$ ./vendor/bin/phing purge-rdf-content
  [Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "rdf-entity-purge" is not defined.                      
                                                                  

Exception trace:
 Symfony\Component\Console\Application->find() at /home/pieter/v/joinup/vendor/drush/drush/src/Application.php:234
 Drush\Application->bootstrapAndFind() at /home/pieter/v/joinup/vendor/drush/drush/src/Application.php:191
 Drush\Application->find() at /home/pieter/v/joinup/vendor/symfony/console/Application.php:229
 Symfony\Component\Console\Application->doRun() at /home/pieter/v/joinup/vendor/symfony/console/Application.php:148
 Symfony\Component\Console\Application->run() at /home/pieter/v/joinup/vendor/drush/drush/src/Runtime/Runtime.php:112
 Drush\Runtime\Runtime->doRun() at /home/pieter/v/joinup/vendor/drush/drush/src/Runtime/Runtime.php:41
 Drush\Runtime\Runtime->run() at /home/pieter/v/joinup/vendor/drush/drush/drush.php:66
 require() at /home/pieter/v/joinup/vendor/drush/drush/drush:4
```

This is because the Drush command this relies on has never been ported to Drush 9.

We can safely remove it because in the meantime we have the `purge-virtuoso-backend` Phing target which serves the same purpose.