### PR TITLE
4471: Unify the filters on the members page and expose them

### DIFF
--- a/tests/features/collection/collection.member_overview.feature
+++ b/tests/features/collection/collection.member_overview.feature
@@ -15,11 +15,11 @@ Feature: Collection membership overview
       # We're adding many users so we can test the different roles and states,
       #  as well as the pager. 12 users are shown per page.
       | Username              | First name | Family name | Photo        | Business title                  |
-      | Ruby Robert           | Ruby       | Robert      | leonardo.jpg | Chairman                        |
+      | Ruby Valenta          | Ruby       | Robert      | leonardo.jpg | Chairman                        |
       | Bohumil Unterbrink    | Bohumil    | Unterbrink  | ada.png      | Senior Executive Vice President |
       | Isabell Zahariev      | Isabell    | Zahariev    | charles.jpg  | Chief Executive Officer         |
       | Gemma Hackett         | Gemma      | Hackett     | tim.jpg      | President                       |
-      | Delicia Hart          | Delicia    | Hart        | alan.jpg     | Executive Director              |
+      | Delicia Hart Val      | Delicia    | Hart        | alan.jpg     | Executive Director              |
       | Sukhrab Valenta       | Sukhrab    | Valenta     | linus.jpeg   | Managing Director               |
       | Jun Schrader          | Jun        | Schrader    | blaise.jpg   | General Manager                 |
       | Ingibjörg De Snaaijer | Ingibjörg  | De Snaaijer | richard.jpg  | Department Head                 |
@@ -36,11 +36,11 @@ Feature: Collection membership overview
       | Jubilant Robots | Fresh oil harvest! | logo.png | banner.jpg | Ayodele Sommer | Nita Yang           | validated |
     And the following collection user memberships:
       | collection      | user                  | roles       | state   |
-      | Jubilant Robots | Ruby Robert           | owner       |         |
+      | Jubilant Robots | Ruby Valenta          | owner       |         |
       | Jubilant Robots | Bohumil Unterbrink    | facilitator |         |
       | Jubilant Robots | Isabell Zahariev      |             | blocked |
       | Jubilant Robots | Gemma Hackett         |             | pending |
-      | Jubilant Robots | Delicia Hart          | facilitator |         |
+      | Jubilant Robots | Delicia Hart Val      | facilitator |         |
       | Jubilant Robots | Sukhrab Valenta       | facilitator |         |
       | Jubilant Robots | Jun Schrader          |             |         |
       | Jubilant Robots | Ingibjörg De Snaaijer |             |         |
@@ -107,6 +107,11 @@ Feature: Collection membership overview
       | Delicia Hart       |
       | Ruby Robert        |
       | Sukhrab Valenta    |
+
+    When I fill in "Type something to filter the list" with "val"
+    And I press "Apply"
+    Then I should see the following tiles in the correct order:
+      | Sukhrab Valenta |
 
     # Clicking the user name should lead to the user profile page.
     When I click "Sukhrab Valenta"

--- a/tests/features/collection/collection.member_overview_filtering.feature
+++ b/tests/features/collection/collection.member_overview_filtering.feature
@@ -1,19 +1,19 @@
 @api
-Feature: Filtering the member list
+Feature: Type something to filter the listing the member list
   In order to quickly find a particular member
   As a moderator
   I need to be able to filter the member list
 
   Background:
     Given users:
-      | Username   | First name | Family name | Roles     |
-      | séamusline | Séamus     | Kingsbrooke | moderator |
-      | emeritous  | King       | Seabrooke   |           |
-      | user049230 | King       | Emerson     |           |
-      | kingseamus | Seamus     | Emerson     |           |
-      | brookebeau | Brooke     | Kingsley    |           |
-      | iambroke   | Nell       | Gibb        |           |
-      | queenson   | Queen      | Emerson     |           |
+      | Username   | First name | Family name | Roles     | E-mail                 |
+      | séamusline | Séamus     | Kingsbrooke | moderator | seamusline@example.com |
+      | emeritous  | King       | Seabrooke   |           | emeritous@example.com  |
+      | user049230 | King       | Emerson     |           | user049230@example.com |
+      | kingseamus | Seamus     | Emerson     |           | kingseamus@example.com |
+      | brookebeau | Brooke     | Kingsley    |           | brookebeau@example.com |
+      | iambroke   | Nell       | Gibb        |           | iambroke@example.com   |
+      | queenson   | Queen      | Emerson     |           | queenson@example.com   |
     And the following collection:
       | title         | Coffee makers                  |
       | description   | Coffee is needed for survival. |
@@ -27,101 +27,80 @@ Feature: Filtering the member list
       | Coffee makers | brookebeau |             | 01-03-2018 00:00 | active  |
       | Coffee makers | iambroke   |             | 01-02-2018 00:00 | blocked |
 
-  Scenario Outline: Only moderators are allowed to filter users in the collection members page.
+  Scenario Outline: All users are allowed to filter the users by a combined search field and the role.
     Given I am logged in as "<user>"
     When I go to the homepage of the "Coffee makers" collection
     And I click "Members" in the "Left sidebar"
-    Then the following fields should not be present "Username, First name, Family name"
-    But the following fields should be present "Roles"
+    Then the following fields should be present "Type something to filter the list, Roles"
 
     Examples:
       | user       |
+      | séamusline |
       | emeritous  |
       | user049230 |
       | kingseamus |
       | queenson   |
 
-  Scenario: Moderators should be able to filter users in the collection members page.
+  Scenario: Moderators should be able to filter users in the table in the collection members page.
     When I am logged in as "séamusline"
     And I go to the homepage of the "Coffee makers" collection
     And I click "Members" in the "Left sidebar"
-    Then the following fields should be present "Username, First name, Family name"
-
-    When I fill in "Username" with "bro"
+    And I fill in "Type something to filter the list" with "bro"
     And I press "Apply"
+
     Then the "member administration" table should be:
       # The first column is empty as it contains the bulk operations checkbox.
       # @todo: Fix this after ISAICP-4836 is implemented.
-      |  | Name            | Member since            | State   | Roles |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
     # Clicking "Name" will sort the table by descending name order.
     When I click "Name"
     Then the "member administration" table should be:
-      |  | Name            | Member since            | State   | Roles |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
 
     # Clicking "Member since" will sort the table by ascending created order.
     When I click "Member since"
     Then the "member administration" table should be:
-      |  | Name            | Member since            | State   | Roles |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
 
     # Clicking "Member since" again will sort the table by descending created order.
     When I click "Member since"
     Then the "member administration" table should be:
-      |  | Name            | Member since            | State   | Roles |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
 
     # Clicking "State" will sort the table by ascending state order.
     When I click "State"
     Then the "member administration" table should be:
-      |  | Name            | Member since            | State   | Roles |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
 
     # Clicking "State" again will sort the table by descending state order.
     When I click "State"
     Then the "member administration" table should be:
-      |  | Name            | Member since            | State   | Roles |
-      |  | Nell Gibb       | Thu, 01/02/2018 - 00:00 | blocked |       |
-      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |       |
+      |  | Name            | Member since            | State   | Roles                                    |
+      |  | King Seabrooke  | Mon, 01/01/2018 - 00:00 | active  | Collection owner, Collection facilitator |
+      |  | Brooke Kingsley | Thu, 01/03/2018 - 00:00 | active  |                                          |
 
-    Then I should see the link "Brooke Kingsley"
-    And I should see the link "Nell Gibb"
-    But I should not see the link "King Seabrooke"
-
-    When I clear the content of the field "Username"
-    When I fill in "First name" with "King"
+    When I fill in "Type something to filter the list" with "King"
     And I press "Apply"
     Then I should see the link "King Seabrooke"
     And I should see the link "King Emerson"
-    But I should not see the link "Brooke Kingsley"
-    And I should not see the link "Seamus Emerson"
+    And I should see the link "Brooke Kingsley"
 
-    When I clear the field "First name"
-    And I fill in "Family name" with "eme"
-    And I press "Apply"
-    Then I should see the link "King Emerson"
-    And I should see the link "Seamus Emerson"
-    But I should not see the link "King Seabrooke"
-
-    When I fill in "Username" with "use"
-    And I press "Apply"
-    Then I should see the link "King Emerson"
-    But I should not see the link "Seamus Emerson"
-
-    When I clear the field "Username"
-    And I clear the field "Family name"
+    When I clear the field "Type something to filter the list"
     And I press "Apply"
     And I select "Owner (1)" from "Roles"
     And I press "Apply"
     Then I should see the link "King Seabrooke"
     But I should not see the link "King Emerson"
-    And I should not see the link "Seamus Emerson"
     And I should not see the link "Brooke Kingsley"
     And I should not see the link "Nell Gibb"
 
@@ -129,10 +108,17 @@ Feature: Filtering the member list
     And I press "Apply"
     Then I should see the link "King Emerson"
     And I should see the link "King Seabrooke"
-    But I should not see the link "Seamus Emerson"
     And I should not see the link "Brooke Kingsley"
     And I should not see the link "Nell Gibb"
-    And I fill in "Family name" with "eme"
+    # "eme" also matches "King Seabrooke" due to the username "emeritous"
+    And I fill in "Type something to filter the list" with "eme"
+    And I press "Apply"
+    Then I should see the link "King Emerson"
+    But I should not see the link "King Seabrooke"
+    And the option with text "Facilitator (1)" from select "Roles" is selected
+
+    # Ensure that filtering is based in all words.
+    When I fill in "Type something to filter the list" with "King Emerson"
     And I press "Apply"
     Then I should see the link "King Emerson"
     But I should not see the link "King Seabrooke"

--- a/tests/features/solution/solution.member_overview.feature
+++ b/tests/features/solution/solution.member_overview.feature
@@ -14,7 +14,7 @@ Feature: Solution membership overview
       | Ffransis Ecclestone | Ffransis   | Ecclestone  | charles.jpg  | Chief Executive Officer         |
       | Paulinho Jahoda     | Paulinho   | Jahoda      | tim.jpg      | President                       |
       | Aušra Buhr          | Aušra      | Buhr        | alan.jpg     | Executive Director              |
-      | Gina Forney         | Gina       | Forney      | linus.jpeg   | Managing Director               |
+      | Gina Forney Buhr    | Gina       | Forney      | linus.jpeg   | Managing Director               |
       | Karna McReynolds    | Karna      | McReynolds  | blaise.jpg   | General Manager                 |
       | Dilek Bannister     | Dilek      | Bannister   | richard.jpg  | Department Head                 |
       | Fadl Sherman        | Fadl       | Sherman     | leonardo.jpg | Deputy General Manager          |
@@ -36,7 +36,7 @@ Feature: Solution membership overview
       | Growing zone | Ffransis Ecclestone |             | blocked |
       | Growing zone | Paulinho Jahoda     |             | pending |
       | Growing zone | Aušra Buhr          | facilitator |         |
-      | Growing zone | Gina Forney         | facilitator |         |
+      | Growing zone | Gina Forney Buhr    | facilitator |         |
       | Growing zone | Karna McReynolds    |             |         |
       | Growing zone | Dilek Bannister     |             |         |
       | Growing zone | Fadl Sherman        |             |         |
@@ -104,6 +104,11 @@ Feature: Solution membership overview
       | Fulvia Gabrielson  |
       | Gina Forney        |
 
+    When I fill in "Type something to filter the list" with "buhr"
+    And I press "Apply"
+    Then I should see the following tiles in the correct order:
+      | Aušra Buhr  |
+
     # Clicking the user name should lead to the user profile page.
-    When I click "Ariadna Astrauskas"
-    Then I should see the heading "Ariadna Astrauskas"
+    When I click "Aušra Buhr"
+    Then I should see the heading "Aušra Buhr"

--- a/tests/features/solution/solution.member_overview_filtering.feature
+++ b/tests/features/solution/solution.member_overview_filtering.feature
@@ -1,5 +1,5 @@
 @api
-Feature: Filtering the member list
+Feature: Type something to filter the listing the member list
   In order to quickly find a particular member
   As a moderator
   I need to be able to filter the member list
@@ -34,11 +34,11 @@ Feature: Filtering the member list
     Given I am logged in as "<user>"
     When I go to the homepage of the "Coffee grinders" solution
     And I click "Members" in the "Left sidebar"
-    Then the following fields should not be present "Username, First name, Family name"
-    But the following fields should be present "Roles"
+    But the following fields should be present "Type something to filter the list, Roles"
 
     Examples:
       | user         |
+      | sludge       |
       | ledge        |
       | user13343    |
       | jackolantern |
@@ -48,36 +48,14 @@ Feature: Filtering the member list
     Given I am logged in as "sludge"
     When I go to the homepage of the "Coffee grinders" solution
     And I click "Members" in the "Left sidebar"
-    Then the following fields should be present "Username, First name, Family name"
-
-    When I fill in "Username" with "right"
+    And I fill in "Type something to filter the list" with "right"
     And I press "Apply"
-    Then I should see the link "Wright Jackson"
-    And I should see the link "Lavonne Atkins"
-    But I should not see the link "Jack Cartwright"
+    And I should see the link "Jack Cartwright"
+    And I should see the link "Wright Jackson"
+    # Matches by username should not be shown - regression check.
+    But I should not see the link "Lavonne Atkins"
 
-    When I clear the content of the field "Username"
-    When I fill in "First name" with "Jack"
-    And I press "Apply"
-    Then I should see the link "Jack Cartwright"
-    And I should see the link "Jack Edgar"
-    But I should not see the link "Wright Jackson"
-    And I should not see the link "Carter Edgar"
-
-    When I clear the field "First name"
-    And I fill in "Family name" with "Edg"
-    And I press "Apply"
-    Then I should see the link "Jack Edgar"
-    And I should see the link "Carter Edgar"
-    But I should not see the link "Jack Cartwright"
-
-    When I fill in "Username" with "use"
-    And I press "Apply"
-    Then I should see the link "Jack Edgar"
-    But I should not see the link "Carter Edgar"
-
-    When I clear the content of the field "Username"
-    And I clear the content of the field "Family name"
+    When I clear the content of the field "Type something to filter the list"
     And I press "Apply"
     And I select "Owner (1)" from "Roles"
     And I press "Apply"
@@ -94,8 +72,22 @@ Feature: Filtering the member list
     But I should not see the link "Carter Edgar"
     And I should not see the link "Wright Jackson"
     And I should not see the link "Lavonne Atkins"
-    And I fill in "Family name" with "edg"
+    And I fill in "Type something to filter the list" with "edg"
+    And I press "Apply"
+    Then I should see the link "Jack Edgar"
+    And the option with text "Facilitator (1)" from select "Roles" is selected
+
+    # Ensure that combined filters change the numbers in the "Roles" selection box.
+    When I fill in "Type something to filter the list" with "Cartwright"
+    And I press "Apply"
+    Then I should see the link "Jack Cartwright"
+    But I should not see the link "Jack Edgar"
+    And the option with text "Facilitator (1)" from select "Roles" is selected
+
+    # Ensure that filtering is based in all words.
+    When I fill in "Type something to filter the list" with "Jack Edgar"
     And I press "Apply"
     Then I should see the link "Jack Edgar"
     But I should not see the link "Jack Cartwright"
+    And I should not see the link "Carter Edgar"
     And the option with text "Facilitator (1)" from select "Roles" is selected

--- a/web/profiles/joinup/config/install/views.view.members_overview.yml
+++ b/web/profiles/joinup/config/install/views.view.members_overview.yml
@@ -1,10 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+  - field.storage.user.field_user_family_name
+  - field.storage.user.field_user_first_name
   module:
-    - joinup_core
-    - og
-    - user
+  - joinup_core
+  - og
+  - user
 id: members_overview
 label: 'Members overview (public)'
 module: views
@@ -68,7 +71,13 @@ display:
       style:
         type: tiles
       row:
-        type: 'entity:og_membership'
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            rendered_entity: rendered_entity
+          separator: ''
+          hide_empty: false
       fields:
         rendered_entity:
           table: og_membership
@@ -122,7 +131,299 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: default
+        field_user_family_name:
+          id: field_user_family_name
+          table: user__field_user_family_name
+          field: field_user_family_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_user_first_name:
+          id: field_user_first_name
+          table: user__field_user_first_name
+          field: field_user_first_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: user
+          entity_field: name
+          plugin_id: field
       filters:
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: allwords
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: "Type something to filter the list"
+            description: ''
+            use_operator: false
+            operator: combine_op
+            identifier: combine
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              moderator: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: 'Combine fields filter'
+            description: null
+            identifier: combine
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          fields:
+            field_user_family_name: field_user_family_name
+            field_user_first_name: field_user_first_name
+          plugin_id: combine
+        roles_target_id:
+          id: roles_target_id
+          table: og_membership__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: roles_target_id_op
+            label: Roles
+            description: null
+            use_operator: false
+            operator: roles_target_id_op
+            identifier: roles_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: true
+          group_info:
+            label: Roles
+            description: ''
+            identifier: roles_target_id
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Owner
+                operator: '='
+                value: rdf_entity-collection-administrator
+              2:
+                title: Facilitator
+                operator: '='
+                value: rdf_entity-collection-facilitator
+              3:
+                title: Owner
+                operator: '='
+                value: rdf_entity-solution-administrator
+              4:
+                title: Facilitator
+                operator: '='
+                value: rdf_entity-solution-facilitator
+          entity_type: og_membership
+          entity_field: roles
+          plugin_id: string
         state:
           id: state
           table: og_membership
@@ -199,60 +500,6 @@ display:
           entity_type: user
           entity_field: status
           plugin_id: boolean
-        roles_target_id:
-          id: roles_target_id
-          table: og_membership__roles
-          field: roles_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: roles_target_id_op
-            label: Roles
-            description: null
-            use_operator: false
-            operator: roles_target_id_op
-            identifier: roles_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: true
-          group_info:
-            label: Roles
-            description: ''
-            identifier: roles_target_id
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: Owner
-                operator: '='
-                value: rdf_entity-collection-administrator
-              2:
-                title: Facilitator
-                operator: '='
-                value: rdf_entity-collection-facilitator
-              3:
-                title: Owner
-                operator: '='
-                value: rdf_entity-solution-administrator
-              4:
-                title: Facilitator
-                operator: '='
-                value: rdf_entity-solution-facilitator
-          entity_type: og_membership
-          entity_field: roles
-          plugin_id: string
       sorts:
         field_user_first_name_value:
           id: field_user_first_name_value
@@ -385,8 +632,11 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_interface'
-        - url
-        - url.query_args
+      - 'languages:language_content'
+      - 'languages:language_interface'
+      - url
+      - url.query_args
       tags:
-        - 'config:core.entity_view_display.og_membership.default.default'
+      - 'config:core.entity_view_display.og_membership.default.default'
+      - 'config:field.storage.user.field_user_family_name'
+      - 'config:field.storage.user.field_user_first_name'

--- a/web/profiles/joinup/config/install/views.view.og_members_overview.yml
+++ b/web/profiles/joinup/config/install/views.view.og_members_overview.yml
@@ -1,9 +1,12 @@
 langcode: en
 status: true
 dependencies:
+  config:
+  - field.storage.user.field_user_family_name
+  - field.storage.user.field_user_first_name
   module:
-    - og
-    - user
+  - og
+  - user
 id: og_members_overview
 label: 'Members overview'
 module: views
@@ -174,11 +177,11 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions:
-            - og_membership_add_multiple_roles_action
-            - og_membership_add_single_role_action.administrator
-            - og_membership_delete_action
-            - og_membership_remove_multiple_roles_action
-            - og_membership_remove_single_role_action.administrator
+          - og_membership_add_multiple_roles_action
+          - og_membership_add_single_role_action.administrator
+          - og_membership_delete_action
+          - og_membership_remove_multiple_roles_action
+          - og_membership_remove_single_role_action.administrator
           entity_type: og_membership
           plugin_id: og_membership_bulk_form
         name:
@@ -443,107 +446,151 @@ display:
           entity_type: og_membership
           entity_field: roles
           plugin_id: field
-      filters:
-        name:
-          id: name
-          table: users_field_data
-          field: name
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: name_op
-            label: Username
-            description: ''
-            use_operator: false
-            operator: name_op
-            identifier: username
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              moderator: '0'
-              administrator: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: user
-          entity_field: name
-          plugin_id: string
-        field_user_first_name_value:
-          id: field_user_first_name_value
-          table: user__field_user_first_name
-          field: field_user_first_name_value
-          relationship: uid
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_user_first_name_value_op
-            label: 'First name'
-            description: ''
-            use_operator: false
-            operator: field_user_first_name_value_op
-            identifier: first_name
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              moderator: '0'
-              administrator: '0'
-            placeholder: ''
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: string
-        field_user_family_name_value:
-          id: field_user_family_name_value
+        field_user_family_name:
+          id: field_user_family_name
           table: user__field_user_family_name
-          field: field_user_family_name_value
+          field: field_user_family_name
           relationship: uid
           group_type: group
           admin_label: ''
-          operator: contains
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_user_first_name:
+          id: field_user_first_name
+          table: user__field_user_first_name
+          field: field_user_first_name
+          relationship: uid
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: allwords
           value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: field_user_family_name_value_op
-            label: 'Family name'
+            operator_id: combine_op
+            label: "Type something to filter the list"
             description: ''
             use_operator: false
-            operator: field_user_family_name_value_op
-            identifier: family_name
+            operator: combine_op
+            identifier: combine
             required: false
             remember: false
             multiple: false
@@ -565,7 +612,10 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
+          fields:
+            field_user_family_name: field_user_family_name
+            field_user_first_name: field_user_first_name
+          plugin_id: combine
         roles_target_id:
           id: roles_target_id
           table: og_membership__roles
@@ -742,8 +792,10 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-      tags: {  }
+      - 'languages:language_content'
+      - 'languages:language_interface'
+      - url
+      - url.query_args
+      tags:
+      - 'config:field.storage.user.field_user_family_name'
+      - 'config:field.storage.user.field_user_first_name'

--- a/web/profiles/joinup/joinup.profile
+++ b/web/profiles/joinup/joinup.profile
@@ -255,43 +255,6 @@ function joinup_form_node_form_alter(&$form, FormStateInterface $form_state, $fo
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
- *
- * Alters the members overview for collections and solutions to display a set of
- * filters for privileged users.
- *
- * @todo Remove this when the filters will be improved for use by all users.
- *
- * @see https://webgate.ec.europa.eu/CITnet/jira/browse/ISAICP-4471
- */
-function joinup_form_views_exposed_form_alter(&$form, FormStateInterface $form_state) {
-  $view = $form_state->get('view');
-  if (empty($view) || !$view instanceof ViewExecutable || $view->id() !== 'og_members_overview') {
-    return;
-  }
-
-  $current_user = \Drupal::currentUser();
-  $has_permission = $current_user->hasPermission('filter membership overview');
-  if ($has_permission) {
-    return;
-  }
-
-  $display = $view->getDisplay();
-  foreach ([
-    'name' => 'username',
-    'field_user_first_name_value' => 'first_name',
-    'field_user_family_name_value' => 'family_name',
-  ] as $display_id => $form_element_id) {
-    // If the user doesn't have permission to filter the membership table, deny
-    // access to the filter fields, and also remove the filters from the view
-    // because otherwise Views will try to filter using empty values, and the
-    // result will be empty.
-    $form[$form_element_id]['#access'] = $has_permission;
-    unset($display->handlers['filter'][$display_id]);
-  }
-}
-
-/**
  * Implements hook_field_formatter_third_party_settings_form().
  *
  * Allow adding template suggestions for each field.

--- a/web/themes/joinup/joinup_theme.theme
+++ b/web/themes/joinup/joinup_theme.theme
@@ -1102,7 +1102,7 @@ function joinup_theme_preprocess_joinup_tiles__members_overview(&$variables) {
   /** @var \Drupal\og\OgMembershipInterface $row */
   foreach ($variables['rows'] as &$row) {
     /** @var \Drupal\og\OgMembershipInterface $membership */
-    $membership = $row['content']['#og_membership'];
+    $membership = $result_row = $row['content']['#row']->_entity;
     $row['content'] = $view_builder->view($membership->getOwner(), 'view_mode_tile');
   }
 }


### PR DESCRIPTION
By mistake I prematurely merged the original PR into `develop`. This PR is to be used after the ticket is accepted in UAT.