### PR TITLE
ISAICP-5091: Restore build properties for Solr cores

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -147,19 +147,24 @@ solr.dir = ${solr.vendor.dir}/solr-${solr.version}
 # Search API configuration path.
 solr.config.dir = ${website.modules.dir}/contrib/search_api_solr/solr-conf/6.x
 
-solr.published_core.scheme = http
-solr.published_core.host = localhost
-solr.published_core.port = 8983
-solr.published_core.path = /solr
-solr.published_core.url = ${solr.published_core.scheme}://${solr.published_core.host}:${solr.published_core.port}${solr.published_core.path}
-solr.published_core.core_name = drupal_published
+# Solr core for published content.
+solr.core.published.name = drupal_published
+solr.core.published.scheme = http
+solr.core.published.host = localhost
+solr.core.published.port = 8983
+solr.core.published.path = /solr
+solr.core.published.url = ${solr.core.published.scheme}://${solr.core.published.host}:${solr.core.published.port}${solr.core.published.path}
+solr.core.published.dir = ${solr.dir}/server/solr/${solr.core.published.name}
 
-solr.unpublished_core.scheme = http
-solr.unpublished_core.host = localhost
-solr.unpublished_core.port = 8983
-solr.unpublished_core.path = /solr
-solr.unpublished_core.url = ${solr.unpublished_core.scheme}://${solr.unpublished_core.host}:${solr.unpublished_core.port}${solr.unpublished_core.path}
-solr.unpublished_core.core_name = drupal_unpublished
+# Solr core for unpublished content.
+solr.core.unpublished.name = drupal_unpublished
+solr.core.unpublished.scheme = http
+solr.core.unpublished.host = localhost
+solr.core.unpublished.port = 8983
+solr.core.unpublished.path = /solr
+solr.core.unpublished.url = ${solr.core.unpublished.scheme}://${solr.core.unpublished.host}:${solr.core.unpublished.port}${solr.core.unpublished.path}
+solr.core.unpublished.dir = ${solr.dir}/server/solr/${solr.core.unpublished.name}
+
 
 # Development options
 # -------------------

--- a/build.properties.docker
+++ b/build.properties.docker
@@ -9,8 +9,8 @@ sparql.host = virtuoso
 sparql.dsn = virtuoso
 
 # Solr connection.
-solr.published_core.host = solr_published
-solr.unpublished_core.host = solr_unpublished
+solr.core.published.host = solr_published
+solr.core.unpublished.host = solr_unpublished
 
 # The base URL. This is used for doing functional tests in Behat and PHPUnit.
 drupal.base_url = http://web

--- a/build.solr.xml
+++ b/build.solr.xml
@@ -108,7 +108,7 @@
             <else>
                 <!-- Create the Solr core. -->
                 <exec dir="${solr.dir}"
-                      command="./bin/solr create_core -c ${solr.core.published}"
+                      command="./bin/solr create_core -c ${solr.core.published.name}"
                       checkreturn="true"
                       passthru="true"/>
                 <!-- Copy the configuration. -->
@@ -125,7 +125,7 @@
             <else>
                 <!-- Create the Solr core. -->
                 <exec dir="${solr.dir}"
-                      command="./bin/solr create_core -c ${solr.core.unpublished}"
+                      command="./bin/solr create_core -c ${solr.core.unpublished.name}"
                       checkreturn="true"
                       passthru="true"/>
                 <!-- Copy the configuration. -->
@@ -157,16 +157,16 @@
         </reflexive>
         <append
                 destFile="${website.settings.local.php}"
-                text="${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['scheme'] = '${solr.published_core.scheme}';
-${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['host'] = '${solr.published_core.host}';
-${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['port'] = '${solr.published_core.port}';
-${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['path'] = '${solr.published_core.path}';
-${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['core'] = '${solr.published_core.core_name}';
-${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['scheme'] = '${solr.unpublished_core.scheme}';
-${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['host'] = '${solr.unpublished_core.host}';
-${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['port'] = '${solr.unpublished_core.port}';
-${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['path'] = '${solr.unpublished_core.path}';
-${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['core'] = '${solr.unpublished_core.core_name}';${line.separator}"/>
+                text="${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['scheme'] = '${solr.core.published.scheme}';
+${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['host'] = '${solr.core.published.host}';
+${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['port'] = '${solr.core.published.port}';
+${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['path'] = '${solr.core.published.path}';
+${line.separator}$config['search_api.server.solr_published']['backend_config']['connector_config']['core'] = '${solr.core.published.name}';
+${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['scheme'] = '${solr.core.unpublished.scheme}';
+${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['host'] = '${solr.core.unpublished.host}';
+${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['port'] = '${solr.core.unpublished.port}';
+${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['path'] = '${solr.core.unpublished.path}';
+${line.separator}$config['search_api.server.solr_unpublished']['backend_config']['connector_config']['core'] = '${solr.core.unpublished.name}';${line.separator}"/>
     </target>
 
     <target
@@ -195,9 +195,9 @@ ${line.separator}$config['search_api.server.solr_unpublished']['backend_config']
     </target>
 
     <target name="purge-solr-backend" description="Empty Solr cores">
-        <exec command="curl --verbose '${solr.published_core.url}/${solr.published_core.core_name}/update?stream.body=&lt;delete&gt;&lt;query&gt;*:*&lt;/query&gt;&lt;/delete&gt;&amp;commit=true'"
+        <exec command="curl --verbose '${solr.core.published.url}/${solr.core.published.name}/update?stream.body=&lt;delete&gt;&lt;query&gt;*:*&lt;/query&gt;&lt;/delete&gt;&amp;commit=true'"
               passthru="true"/>
-        <exec command="curl --verbose '${solr.unpublished_core.url}/${solr.unpublished_core.core_name}/update?stream.body=&lt;delete&gt;&lt;query&gt;*:*&lt;/query&gt;&lt;/delete&gt;&amp;commit=true'"
+        <exec command="curl --verbose '${solr.core.unpublished.url}/${solr.core.unpublished.name}/update?stream.body=&lt;delete&gt;&lt;query&gt;*:*&lt;/query&gt;&lt;/delete&gt;&amp;commit=true'"
               passthru="true"/>
     </target>
 


### PR DESCRIPTION
The build properties for the Solr server were integrated in the properties for the Solr cores when we provided Docker integration. This made it possible to host each core on a different Solr server. Unfortunately the properties were not applied on all existing Phing targets which broke the Solr integration on local (non-Docker) environments.