### PR TITLE
Add missing test group

### DIFF
--- a/web/modules/custom/rdf_schema_field_validation/tests/src/Kernel/RdfSchemaFieldValidationTest.php
+++ b/web/modules/custom/rdf_schema_field_validation/tests/src/Kernel/RdfSchemaFieldValidationTest.php
@@ -8,6 +8,8 @@ use EasyRdf\Graph;
 
 /**
  * Suite that tests the rdf field schema validation service.
+ *
+ * @group rdf_schema_field_validation
  */
 class RdfSchemaFieldValidationTest extends JoinupKernelTestBase {
 


### PR DESCRIPTION
When the Simpletest module is enabled a `MissingGroupException` is being thrown for `RdfSchemaFieldValidationTest`.