### PR TITLE
Update step definitions to be more grammatically correct

### DIFF
--- a/tests/features/joinup_document/document.moderation.feature
+++ b/tests/features/joinup_document/document.moderation.feature
@@ -34,7 +34,7 @@ Feature: Document moderation
     # create content, authenticated users that are not members can create
     # documents.
     When I am logged in as "Crab y Patties"
-    And go to the homepage of the "The Naked Ashes" collection
+    And I go to the homepage of the "The Naked Ashes" collection
     And I click "Add document" in the plus button menu
     # Post moderated collections allow publishing content directly.
     And I should see the button "Publish"

--- a/tests/features/joinup_event/event.moderation.feature
+++ b/tests/features/joinup_event/event.moderation.feature
@@ -34,7 +34,7 @@ Feature: Event moderation
     # create content, authenticated users that are not members can create
     # events.
     When I am logged in as "Salvador Thomas"
-    And go to the homepage of the "Wet Lords" collection
+    And I go to the homepage of the "Wet Lords" collection
     And I click "Add event" in the plus button menu
     # Post moderated collections allow publishing content directly.
     And I should see the button "Publish"

--- a/tests/src/Context/ScreenshotContext.php
+++ b/tests/src/Context/ScreenshotContext.php
@@ -102,7 +102,7 @@ class ScreenshotContext extends RawMinkContext {
    * @param string $name
    *   The file name.
    *
-   * @Then (I )take a screenshot :name
+   * @Then I take a screenshot :name
    */
   public function takeScreenshot(string $name = NULL) : void {
     $message = "Screenshot created in @file_name";
@@ -112,7 +112,7 @@ class ScreenshotContext extends RawMinkContext {
   /**
    * Saves a screenshot under a predefined name.
    *
-   * @Then (I )take a screenshot
+   * @Then I take a screenshot
    */
   public function takeScreenshotUnnamed() : void {
     $file_name = 'behat-screenshot-' . user_password();

--- a/web/modules/custom/asset_distribution/asset_distribution.behat.inc
+++ b/web/modules/custom/asset_distribution/asset_distribution.behat.inc
@@ -36,10 +36,10 @@ class AssetDistributionSubContext extends DrupalSubContextBase implements Drupal
    * @param string $asset_distribution
    *   The title of the asset distribution.
    *
-   * @When (I )go to (the homepage of )the :asset_distribution distribution
-   * @When (I )visit (the homepage of )the :asset_distribution distribution
-   * @When (I )go to (the homepage of )the :asset_distribution asset distribution
-   * @When (I )visit (the homepage of )the :asset_distribution asset distribution
+   * @When I go to (the homepage of )the :asset_distribution distribution
+   * @When I visit (the homepage of )the :asset_distribution distribution
+   * @When I go to (the homepage of )the :asset_distribution asset distribution
+   * @When I visit (the homepage of )the :asset_distribution asset distribution
    */
   public function visitDistribution($asset_distribution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $asset_distribution */
@@ -53,8 +53,8 @@ class AssetDistributionSubContext extends DrupalSubContextBase implements Drupal
    * @param string $asset_distribution
    *   The title of the $asset_distribution.
    *
-   * @When (I )go to the :asset_distribution asset distribution edit form
-   * @When (I )visit the :asset_distribution asset distribution edit form
+   * @When I go to the :asset_distribution asset distribution edit form
+   * @When I visit the :asset_distribution asset distribution edit form
    */
   public function visitEditAssetDistribution($asset_distribution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $asset_distribution */
@@ -186,7 +186,7 @@ class AssetDistributionSubContext extends DrupalSubContextBase implements Drupal
    * @param string $asset_distribution
    *   The title of the asset distribution.
    *
-   * @When (I )delete the :asset_distribution asset distribution
+   * @When I delete the :asset_distribution asset distribution
    */
   public function deleteAssetDistribution($asset_distribution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $asset_distribution */

--- a/web/modules/custom/asset_release/asset_release.behat.inc
+++ b/web/modules/custom/asset_release/asset_release.behat.inc
@@ -37,8 +37,8 @@ class AssetReleaseSubContext extends DrupalSubContextBase implements DrupalSubCo
    * @param string $asset_release
    *   The name of the asset_release.
    *
-   * @When (I )go to (the homepage of )the :asset_release release
-   * @When (I )visit (the homepage of )the :asset_release release
+   * @When I go to (the homepage of )the :asset_release release
+   * @When I visit (the homepage of )the :asset_release release
    */
   public function visitRelease(string $asset_release): void {
     /** @var \Drupal\rdf_entity\Entity\Rdf $asset_release */
@@ -175,7 +175,7 @@ class AssetReleaseSubContext extends DrupalSubContextBase implements DrupalSubCo
    * @param string $asset_release
    *   The name of the asset release.
    *
-   * @When (I )delete the :asset_release release
+   * @When I delete the :asset_release release
    */
   public function deleteAssetRelease(string $asset_release): void {
     /** @var \Drupal\rdf_entity\RdfInterface $asset_release */

--- a/web/modules/custom/collection/collection.behat.inc
+++ b/web/modules/custom/collection/collection.behat.inc
@@ -50,8 +50,8 @@ class CollectionSubContext extends DrupalSubContextBase implements DrupalSubCont
   /**
    * Navigates to the propose collection form.
    *
-   * @When (I )go to the propose collection form
-   * @When (I )visit the propose collection form
+   * @When I go to the propose collection form
+   * @When I visit the propose collection form
    */
   public function visitProposeCollectionForm() {
     $this->visitPath('propose/collection');
@@ -63,8 +63,8 @@ class CollectionSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $collection
    *   The title of the collection.
    *
-   * @When (I )go to (the homepage of )the :collection collection
-   * @When (I )visit (the homepage of )the :collection collection
+   * @When I go to (the homepage of )the :collection collection
+   * @When I visit (the homepage of )the :collection collection
    */
   public function visitCollection($collection) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $collection */
@@ -98,8 +98,8 @@ class CollectionSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $collection
    *   The title of the collection.
    *
-   * @When (I )go to the :collection collection edit form
-   * @When (I )visit the :collection collection edit form
+   * @When I go to the :collection collection edit form
+   * @When I visit the :collection collection edit form
    */
   public function visitEditCollection($collection) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $collection */
@@ -111,7 +111,7 @@ class CollectionSubContext extends DrupalSubContextBase implements DrupalSubCont
   /**
    * Navigates to the collections overview page.
    *
-   * @When (I )visit the collection overview page
+   * @When I visit the collection overview( page)
    */
   public function visitCollectionOverviewPage() {
     $this->visitPath('/collections');
@@ -361,7 +361,7 @@ class CollectionSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $collection
    *   The title of the collection.
    *
-   * @When (I )delete the :collection collection
+   * @When I delete the :collection collection
    */
   public function deleteCollection($collection) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $collection */

--- a/web/modules/custom/contact_form/contact_form.behat.inc
+++ b/web/modules/custom/contact_form/contact_form.behat.inc
@@ -15,8 +15,8 @@ class ContactFormSubContext extends DrupalSubContextBase {
   /**
    * Navigates to the contact form.
    *
-   * @When (I )go to the contact form
-   * @When (I )visit the contact form
+   * @When I go to the contact form
+   * @When I visit the contact form
    * @When I am on the contact form
    */
   public function visitContactForm() {

--- a/web/modules/custom/contact_information/contact_information.behat.inc
+++ b/web/modules/custom/contact_information/contact_information.behat.inc
@@ -32,10 +32,10 @@ class ContactInformationSubContext extends DrupalSubContextBase implements Drupa
    * @param string $label
    *   The label of the contact information entity.
    *
-   * @When (I )go to (the homepage of )the :label contact
-   * @When (I )visit (the homepage of )the :label contact
-   * @When (I )go to the :label contact information page
-   * @When (I )visit the :label contact information page
+   * @When I go to (the homepage of )the :label contact
+   * @When I visit (the homepage of )the :label contact
+   * @When I go to the :label contact information page
+   * @When I visit the :label contact information page
    */
   public function visitContactInformationPage($label) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $entity */

--- a/web/modules/custom/custom_page/custom_page.behat.inc
+++ b/web/modules/custom/custom_page/custom_page.behat.inc
@@ -84,8 +84,8 @@ class CustomPageSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $title
    *   The name of the custom page.
    *
-   * @When (I )go to the :title custom page
-   * @When (I )visit the :title custom page
+   * @When I go to the :title custom page
+   * @When I visit the :title custom page
    */
   public function visitCustomPage(string $title): void {
     /** @var \Drupal\node\Entity\Node $node */

--- a/web/modules/custom/joinup_discussion/joinup_discussion.behat.inc
+++ b/web/modules/custom/joinup_discussion/joinup_discussion.behat.inc
@@ -24,8 +24,8 @@ class DiscussionSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $title
    *   The name of the discussion.
    *
-   * @When (I )go to the :title discussion
-   * @When (I )visit the :title discussion
+   * @When I go to the :title discussion
+   * @When I visit the :title discussion
    */
   public function visitDiscussion($title) {
     /** @var \Drupal\node\Entity\Node $node */

--- a/web/modules/custom/joinup_document/joinup_document.behat.inc
+++ b/web/modules/custom/joinup_document/joinup_document.behat.inc
@@ -28,8 +28,8 @@ class DocumentSubContext extends DrupalSubContextBase implements DrupalSubContex
    * @param string $title
    *   The name of the document.
    *
-   * @When (I )go to the :title document
-   * @When (I )visit the :title document
+   * @When I go to the :title document
+   * @When I visit the :title document
    */
   public function visitDocument($title) {
     /** @var \Drupal\node\Entity\Node $node */

--- a/web/modules/custom/joinup_event/joinup_event.behat.inc
+++ b/web/modules/custom/joinup_event/joinup_event.behat.inc
@@ -33,8 +33,8 @@ class EventSubContext extends DrupalSubContextBase {
    * @param string $title
    *   The name of the event.
    *
-   * @When (I )go to the :title event
-   * @When (I )visit the :title event
+   * @When I go to the :title event
+   * @When I visit the :title event
    */
   public function visitEvent(string $title): void {
     /** @var \Drupal\node\Entity\Node $node */

--- a/web/modules/custom/joinup_licence/joinup_licence.behat.inc
+++ b/web/modules/custom/joinup_licence/joinup_licence.behat.inc
@@ -32,8 +32,8 @@ class LicenceSubContext extends DrupalSubContextBase implements DrupalSubContext
    * @param string $licence
    *   The title of the licence.
    *
-   * @When (I )go to (the homepage of )the :licence licence
-   * @When (I )visit (the homepage of )the :licence licence
+   * @When I go to (the homepage of )the :licence licence
+   * @When I visit (the homepage of )the :licence licence
    */
   public function visitLicence($licence) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $licence */
@@ -49,8 +49,8 @@ class LicenceSubContext extends DrupalSubContextBase implements DrupalSubContext
    * @param string $format
    *   The RDF serialization format.
    *
-   * @When (I )go to (the homepage of )the :licence licence in the :format serialisation.
-   * @When (I )visit (the homepage of )the :licence licence in the :format serialisation.
+   * @When I go to (the homepage of )the :licence licence in the :format serialisation.
+   * @When I visit (the homepage of )the :licence licence in the :format serialisation.
    */
   public function visitLicenceWithFormat($licence, $format) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $collection */
@@ -159,7 +159,7 @@ class LicenceSubContext extends DrupalSubContextBase implements DrupalSubContext
    * @param string $licence
    *   The title of the licence.
    *
-   * @When (I )delete the :licence licence
+   * @When I delete the :licence licence
    */
   public function deleteLicence($licence) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $licence */

--- a/web/modules/custom/joinup_news/joinup_news.behat.inc
+++ b/web/modules/custom/joinup_news/joinup_news.behat.inc
@@ -22,8 +22,8 @@ class NewsSubContext extends DrupalSubContextBase implements DrupalSubContextInt
    * @param string $title
    *   The name of the news page.
    *
-   * @When (I )go to the :title news
-   * @When (I )visit the :title news
+   * @When I go to the :title news
+   * @When I visit the :title news
    */
   public function visitNewsPage($title) {
     /** @var \Drupal\node\Entity\Node $node */

--- a/web/modules/custom/joinup_user/joinup_user.behat.inc
+++ b/web/modules/custom/joinup_user/joinup_user.behat.inc
@@ -25,8 +25,8 @@ class JoinupUserSubContext extends DrupalSubContextBase implements DrupalSubCont
    * @param string $user
    *   The user name.
    *
-   * @When (I )go to the (public )profile of :user
-   * @When (I )visit the (public )profile of :user
+   * @When I go to the (public )profile of :user
+   * @When I visit the (public )profile of :user
    */
   public function visitUserPublicProfile($user) {
     $this->visitPath($this->getUserByName($user)->url());

--- a/web/modules/custom/owner/owner.behat.inc
+++ b/web/modules/custom/owner/owner.behat.inc
@@ -136,7 +136,7 @@ class OwnerSubContext extends DrupalSubContextBase implements DrupalSubContextIn
    * @throws \Exception
    *   Thrown when the owner field appears empty in the page.
    *
-   * @When (I )set the Owner type(s) to :option
+   * @When I set the Owner type(s) to :option
    */
   public function setOwnerType($options) {
     // Explode into an array.
@@ -169,8 +169,8 @@ class OwnerSubContext extends DrupalSubContextBase implements DrupalSubContextIn
    * @param string $owner
    *   The label of the owner.
    *
-   * @When (I )go to (the homepage of )the :owner owner
-   * @When (I )visit (the homepage of )the :owner owner
+   * @When I go to (the homepage of )the :owner owner
+   * @When I visit (the homepage of )the :owner owner
    */
   public function visitOwner($owner) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $owner */

--- a/web/modules/custom/pipeline/pipeline.behat.inc
+++ b/web/modules/custom/pipeline/pipeline.behat.inc
@@ -15,8 +15,8 @@ class PipelineSubContext extends DrupalSubContextBase {
   /**
    * Navigates to the pipeline orchestrator.
    *
-   * @When (I )go to the pipeline orchestrator
-   * @When (I )visit the pipeline orchestrator
+   * @When I go to the pipeline orchestrator
+   * @When I visit the pipeline orchestrator
    * @When I am on the pipeline orchestrator
    */
   public function visitPipelineOrchestrator() {

--- a/web/modules/custom/solution/solution.behat.inc
+++ b/web/modules/custom/solution/solution.behat.inc
@@ -53,8 +53,8 @@ class SolutionSubContext extends DrupalSubContextBase implements DrupalSubContex
    * @param string $collection
    *   The parent collection.
    *
-   * @When (I )go to the add solution form of the :collection collection
-   * @When (I )visit the add solution form of the :collection collection
+   * @When I go to the add solution form of the :collection collection
+   * @When I visit the add solution form of the :collection collection
    */
   public function visitAddSolutionForm($collection) {
     $collection = $this->getRdfEntityByLabel($collection);
@@ -71,8 +71,8 @@ class SolutionSubContext extends DrupalSubContextBase implements DrupalSubContex
    * @param string $solution
    *   The name of the solution.
    *
-   * @When (I )go to (the homepage of )the :solution solution
-   * @When (I )visit (the homepage of )the :solution solution
+   * @When I go to (the homepage of )the :solution solution
+   * @When I visit (the homepage of )the :solution solution
    */
   public function visitSolution($solution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $solution */
@@ -86,8 +86,8 @@ class SolutionSubContext extends DrupalSubContextBase implements DrupalSubContex
    * @param string $solution
    *   The name of the solution.
    *
-   * @When (I )go to the :solution solution edit form
-   * @When (I )visit the :solution solution edit form
+   * @When I go to the :solution solution edit form
+   * @When I visit the :solution solution edit form
    */
   public function visitEditSolution($solution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $solution */
@@ -296,7 +296,7 @@ class SolutionSubContext extends DrupalSubContextBase implements DrupalSubContex
    * @param string $solution
    *   The name of the solution.
    *
-   * @When (I )delete the :solution solution
+   * @When I delete the :solution solution
    */
   public function deleteSolution($solution) {
     /** @var \Drupal\rdf_entity\Entity\Rdf $solution */

--- a/web/profiles/joinup/joinup.behat.inc
+++ b/web/profiles/joinup/joinup.behat.inc
@@ -415,8 +415,8 @@ class JoinupSubContext extends DrupalSubContextBase {
    * @param string $title
    *   The title of the node.
    *
-   * @When (I )go to the :bundle (content ) :title edit screen
-   * @When (I )visit the :bundle (content ) :title edit screen
+   * @When I go to the :bundle (content ) :title edit screen
+   * @When I visit the :bundle (content ) :title edit screen
    */
   public function visitNodeEditForm($bundle, $title) {
     /** @var \Drupal\node\NodeInterface $node */
@@ -435,8 +435,8 @@ class JoinupSubContext extends DrupalSubContextBase {
    * @param string $title
    *   The name of the news page.
    *
-   * @When (I )go to the content page of the type :type with the title :title
-   * @When (I )visit the content page of the type :type with the title :title
+   * @When I go to the content page of the type :type with the title :title
+   * @When I visit the content page of the type :type with the title :title
    */
   public function visitNodePage($type, $title) {
     /** @var \Drupal\node\Entity\Node $node */


### PR DESCRIPTION
This is flowing out of https://github.com/ec-europa/joinup-dev/pull/1508#discussion_r266019018 in which @idimopoulos remarks that allowing to omit the subject from a step definition is pointless and allows to create user scenarios that are not grammatically correct.

"When am on the homepage" is not correct English :)

I took this out of the previous PR since this practice turned out to be very wide spread and would just confuse the other ticket.