### PR TITLE
ISAICP-5286: Rebuild the cache in between updating the database and p…

### DIFF
--- a/scripts/update_uat.sh
+++ b/scripts/update_uat.sh
@@ -14,6 +14,7 @@ touch disable-config-readonly
 
 ./vendor/bin/drush cache:clear bin config --yes
 ./vendor/bin/drush updatedb --yes
+./vendor/bin/drush cache-rebuild --yes
 ./vendor/bin/drush cs-update --discard-overrides --yes
 ./vendor/bin/drush cache-rebuild --yes
 ./vendor/bin/drush pm:enable stage_file_proxy --yes


### PR DESCRIPTION
…erforming config sync.

This fixes a random failure where the configuration of a new entity type cannot
be applied for a module that has been enabled just before in a post update
hook.