### PR TITLE
The legal notice route no longer exists.

### DIFF
--- a/web/profiles/joinup/joinup.routing.yml
+++ b/web/profiles/joinup/joinup.routing.yml
@@ -69,14 +69,6 @@ joinup.group_administrators_report:
   options:
     _admin_route: TRUE
 
-joinup.legal_notice:
-  path: '/joinup/legal-notice'
-  defaults:
-    _controller: '\Drupal\joinup\Controller\JoinupController::legalNotice'
-    _title: 'Legal notice'
-  requirements:
-    _access: 'TRUE'
-
 joinup.solutions_by_licences_report:
   path: '/admin/reporting/solutions-by-licences'
   defaults:


### PR DESCRIPTION
This route definition reappeared, probably due to a botched merge.