### PR TITLE
ISAICP-5332: Reset the user's default image.

### DIFF
--- a/web/modules/custom/joinup_user/config/install/field.field.user.user.field_user_photo.yml
+++ b/web/modules/custom/joinup_user/config/install/field.field.user.user.field_user_photo.yml
@@ -27,7 +27,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: 7194c32e-425b-4c2b-9027-056c6b7edc2f
+    uuid: 2e24bbc5-dedf-42b0-85cf-35940274c2f8
     alt: ''
     title: ''
     width: 640

--- a/web/modules/custom/joinup_user/joinup_user.install
+++ b/web/modules/custom/joinup_user/joinup_user.install
@@ -5,6 +5,7 @@
  * Install functions of the Joinup user module.
  */
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\file\Entity\File;
 
@@ -70,18 +71,19 @@ function joinup_user_setup_default_avatar() {
   $file_name = 'user_icon.png';
   $file_path = $directory . '/' . $file_name;
   $internal_path = "public://default_images";
-  if (is_file($file_path) && file_prepare_directory($internal_path, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS)) {
-    $file_path = file_unmanaged_copy($file_path, $internal_path, FILE_EXISTS_REPLACE);
+  if (is_file($file_path) && \Drupal::service('file_system')->prepareDirectory($internal_path, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
+    $file_system = \Drupal::service('file_system');
+    if (!isset($destination)) {
+      $destination = file_build_uri($file_system->basename($file_path));
+    }
+    $file_path = $file_system->copy($file_path, $destination, FileSystemInterface::EXISTS_REPLACE);
   }
+  /** @var \Drupal\file\FileInterface $file */
   $file = File::create(['uri' => $file_path]);
+
+  // The uuid is the one assigned to the user photo field so there is no need
+  // to manually edit and assign the file.
+  $file->set('uuid', '2e24bbc5-dedf-42b0-85cf-35940274c2f8');
+  $file->setPermanent();
   $file->save();
-  $config_factory = \Drupal::configFactory();
-  $field_user_photo = $config_factory->getEditable('field.field.user.user.field_user_photo');
-  $default_image = $field_user_photo->get('settings.default_image');
-
-  $default_image['uuid'] = $file->uuid();
-  $default_image['height'] = 615;
-  $default_image['width'] = 640;
-
-  $field_user_photo->set('settings.default_image', $default_image)->save(TRUE);
 }

--- a/web/modules/custom/joinup_user/joinup_user.post_update.php
+++ b/web/modules/custom/joinup_user/joinup_user.post_update.php
@@ -121,3 +121,11 @@ function joinup_user_post_update_spam_accounts(array &$sandbox): ?string {
     return "Finished deleting {$sandbox['progress']} spam accounts.";
   }
 }
+
+/**
+ * Reset the user default icon.
+ */
+function joinup_user_post_update_reset_default_icons() {
+  include_once __DIR__ . '/joinup_user.install';
+  joinup_user_setup_default_avatar();
+}


### PR DESCRIPTION
I can only make assumptions as to why this happened. However, here are some clues.
The first change regarding this is 
```
--- a/web/modules/custom/joinup_user/config/install/field.field.user.user.field_user_photo.yml
+++ b/web/modules/custom/joinup_user/config/install/field.field.user.user.field_user_photo.yml
@@ -27,7 +27,7 @@ settings:
   title_field: false
   title_field_required: false
   default_image:
-    uuid: 7194c32e-425b-4c2b-9027-056c6b7edc2f
+    uuid: 2e24bbc5-dedf-42b0-85cf-35940274c2f8
     alt: ''
     title: ''
     width: 640
```
The first uuid, `7194c32e-425b-4c2b-9027-056c6b7edc2f` was updated in #bd88a2d8 where Pieter re-exported the configuration due to moving to Drupal core 8.4.x.
Before this change, we had it set as empty.
Another clue, is that when using the production database, there is no file with this uuid.

Now the above commit was back in 2017. I cannot consider that this was not working since then.

So my assumption is that we initially installed the default user icon image using the `\joinup_user_setup_default_avatar()` through `\joinup_user_install()` and never bothered checking again. However, when Pieter re-exported the configuration, it might be that he did it using a new installation (where the file was installed and the uuid was different). That did not affect production for a while due to the active snapshot that config_sync was using.
We fixed a bug a few months ago and we reset the snapshot a couple of times. Back then, it probably properly updated the configuration and set the default value to be the one from what Pieter had set back then. In the meantime, that caused the default icon to be non-used which probably caused it to be deleted as well.

What I did in this PR:
* I changed the installation method to directly assign a custom uuid (random) to a file.
* I assigned in the `field.field.user.user.field_user_photo.yml` config file the uuid directly.
* I created an update path for the file to be re-installed.

That way, for new installations, the file is added directly with a uuid and the field is installed with this. For existing installations - and production, the file will be re-created and the field will receive again the uuid directly through the config-sync.

I did not create any tests as this is not happening in new installations. That was a wrong uuid update.