### PR TITLE
Use the correct constant for facilitators

### DIFF
--- a/web/modules/custom/collection/collection.module
+++ b/web/modules/custom/collection/collection.module
@@ -135,7 +135,7 @@ function collection_form_rdf_entity_form_alter(&$form, FormStateInterface $form_
   $option_transitions = [
     // If the option 'Only collection facilitators' was selected before, then
     // take the option 'Only members'.
-    ELibraryCreationOptions::MEMBERS => ELibraryCreationOptions::MEMBERS,
+    ELibraryCreationOptions::FACILITATORS => ELibraryCreationOptions::MEMBERS,
     // If the option 'Any registered user' was selected before, then take the
     // option 'Only members'.
     ELibraryCreationOptions::REGISTERED_USERS => ELibraryCreationOptions::MEMBERS,


### PR DESCRIPTION
I just got a notice for a non-existing array key when editing a test collection. I looked into it and it is because I made a mistake in [commit 99bdf7aa2](https://github.com/ec-europa/joinup-dev/commit/99bdf7aa24bc89a0cfa7d8f2af2b4d2d5a30fd93) when converting integers to constants.

This is the code in question:

```
// If the option 'Only collection facilitators' was selected before, then
// take the option 'Only members'.
ELibraryCreationOptions::MEMBERS => ELibraryCreationOptions::MEMBERS,
```

It is supposed to convert the option that "only facilitators can create content" to "all members members can create content" when a collection is changed from a closed collection to an open collection. The original code was correct (`0` is a facilitator, `1` is a member):

```
0 => 1,
```

But when this was changed to constants it was accidentally changed to only members.

This apparently doesn't have tests, probably because it is a very rare occurrence that people change a collection from closed to open. I will create a followup to add test coverage for this.