### PR TITLE
5550: Run content operations after new modules are installed via CMI

### DIFF
--- a/build.project.xml
+++ b/build.project.xml
@@ -103,7 +103,8 @@
                 assume="yes"
                 root="${website.drupal.dir}"
                 bin="${drush.bin}">
-            <option name="cache-clear" />
+            <option name="cache-clear"/>
+            <option name="no-post-updates"/>
         </drush>
         <drush
                 command="config:import"
@@ -111,6 +112,13 @@
                 root="${website.drupal.dir}"
                 bin="${drush.bin}"
                 verbose="${drush.verbose}">
+        </drush>
+        <drush
+                command="updatedb"
+                assume="yes"
+                root="${website.drupal.dir}"
+                bin="${drush.bin}">
+            <option name="cache-clear"/>
         </drush>
     </target>
 

--- a/scripts/update_production.sh
+++ b/scripts/update_production.sh
@@ -39,8 +39,9 @@ echo "Disabling config_readonly."
 touch disable-config-readonly
 
 ./vendor/bin/drush cache:rebuild --yes &&
-./vendor/bin/drush updatedb --yes --cache-clear &&
+./vendor/bin/drush updatedb --yes --cache-clear --no-post-updates &&
 ./vendor/bin/drush config:import --yes &&
+./vendor/bin/drush updatedb --yes --cache-clear &&
 ./vendor/bin/drush search-api:reset-tracker --yes &&
 
 echo "Rebuilding node access records." &&

--- a/scripts/update_uat.sh
+++ b/scripts/update_uat.sh
@@ -13,8 +13,9 @@ echo "Disabling config_readonly."
 touch disable-config-readonly
 
 ./vendor/bin/drush cache:rebuild --yes
-./vendor/bin/drush updatedb --yes --cache-clear
+./vendor/bin/drush updatedb --yes --cache-clear --no-post-updates
 ./vendor/bin/drush config:import --yes
+./vendor/bin/drush updatedb --yes --cache-clear
 ./vendor/bin/drush pm:enable stage_file_proxy --yes
 
 echo "Rebuilding node access records."

--- a/web/modules/custom/joinup_core/joinup_core.install
+++ b/web/modules/custom/joinup_core/joinup_core.install
@@ -330,3 +330,17 @@ function joinup_core_update_8110() {
       ->setDisplayConfigurable('form', TRUE)
   );
 }
+
+/**
+ * Fix 'default' graph UUID.
+ */
+function joinup_core_update_8111(): void {
+  // If a config have a different UUID in active store compared to staging, the
+  // config is deleted and recreated. But the 'default' graph cannot be deleted,
+  // so we avoid deletion by manually setting its UUID.
+  // @see \Drupal\Core\Config\StorageComparer::addChangelistUpdate()
+  // @see \Drupal\sparql_entity_storage\Entity\SparqlGraph::delete()
+  \Drupal::configFactory()->getEditable('sparql_entity_storage.graph.default')
+    ->set('uuid', 'adb4491f-7cbc-46d9-975d-41bf83b14637')
+    ->save();
+}

--- a/web/profiles/joinup/joinup.post_update.php
+++ b/web/profiles/joinup/joinup.post_update.php
@@ -178,17 +178,3 @@ function joinup_post_update_legal() {
     ],
   ])->save();
 }
-
-/**
- * Fix 'default' graph UUID.
- */
-function joinup_post_update_default_graph(): void {
-  // If a config have a different UUID in active store compared to staging, the
-  // config is deleted and recreated. But the 'default' graph cannot be deleted,
-  // so we avoid deletion by manually setting its UUID.
-  // @see \Drupal\Core\Config\StorageComparer::addChangelistUpdate()
-  // @see \Drupal\sparql_entity_storage\Entity\SparqlGraph::delete()
-  \Drupal::configFactory()->getEditable('sparql_entity_storage.graph.default')
-    ->set('uuid', 'adb4491f-7cbc-46d9-975d-41bf83b14637')
-    ->save();
-}


### PR DESCRIPTION
This is built on top of ISAICP-5051 and blocked on that.