### PR TITLE
ISAICP-5645: Use the clearer terminology 'Follow discussion' instead …

### DIFF
--- a/config/sync/flag.flag.subscribe_discussions.yml
+++ b/config/sync/flag.flag.subscribe_discussions.yml
@@ -5,18 +5,18 @@ dependencies:
   module:
     - joinup_subscription
 id: subscribe_discussions
-label: 'Subscribe discussions'
+label: 'Follow discussions'
 bundles:
   - discussion
 entity_type: node
 global: false
 weight: 0
-flag_short: Subscribe
+flag_short: Follow
 flag_long: ''
-flag_message: 'You have been subscribed to the discussion.'
-unflag_short: Unsubscribe
+flag_message: 'You are now following this discussion and you will receive notifications when someone posts a comment.'
+unflag_short: Unfollow
 unflag_long: ''
-unflag_message: 'You have been unsubscribed from the discussion.'
+unflag_message: 'You are no longer following the discussion.'
 unflag_denied_text: ''
 flag_type: 'entity:node'
 link_type: safe_unflag
@@ -28,8 +28,8 @@ flagTypeConfig:
   extra_permissions:
     owner: '0'
 linkTypeConfig:
-  flag_confirmation: 'Subscribe to this discussion?'
-  unflag_confirmation: 'Unsubscribe from this discussion?'
-  flag_create_button: Subscribe
-  flag_delete_button: Unsubscribe
+  flag_confirmation: 'Follow this discussion?'
+  unflag_confirmation: 'Stop following this discussion?'
+  flag_create_button: Follow
+  flag_delete_button: Unfollow
   form_behavior: modal

--- a/tests/features/joinup_discussion/discussion.subscribe.feature
+++ b/tests/features/joinup_discussion/discussion.subscribe.feature
@@ -1,8 +1,8 @@
 @api
-Feature: Subscribing to discussions
+Feature: Following discussions
   As a member of Joinup
-  I want to subscribe to interesting discussions
-  So that I can stay up to date with its evolvements.
+  I want to follow interesting discussions
+  So that I can stay up to date with its evolvement
 
   Background:
     Given the following collection:
@@ -18,38 +18,38 @@ Feature: Subscribing to discussions
     Then the "Rare butter" discussion should have 0 subscribers
 
   @javascript
-  Scenario: Subscribe to a discussion.
+  Scenario: Follow a discussion.
     When I am an anonymous user
     And I go to the "Rare Butter" discussion
-    Then I should not see the link "Subscribe"
-    And I should not see the link "Unsubscribe"
+    Then I should not see the link "Follow"
+    And I should not see the link "Unfollow"
     # The subscribe links should never be shown for a discussion which is not
     # published.
     When I go to the "Rare Whey" discussion
-    Then I should not see the link "Subscribe"
-    And I should not see the link "Unsubscribe"
+    Then I should not see the link "Follow"
+    And I should not see the link "Unfollow"
 
     When I am logged in as an "authenticated user"
     # The subscribe links should never be shown for a discussion which is not
     # published.
     When I go to the "Rare Whey" discussion
-    Then I should not see the link "Subscribe"
-    And I should not see the link "Unsubscribe"
+    Then I should not see the link "Follow"
+    And I should not see the link "Unfollow"
     And I go to the "Rare Butter" discussion
-    Then I should see the link "Subscribe"
-    And I should not see the link "Unsubscribe"
+    Then I should see the link "Follow"
+    And I should not see the link "Unfollow"
 
-    When I click "Subscribe"
-    Then I should see the link "Unsubscribe"
-    And I should not see the link "Subscribe"
+    When I click "Follow"
+    Then I should see the link "Unfollow"
+    And I should not see the link "Follow"
     And the "Rare butter" discussion should have 1 subscriber
 
-    When I click "Unsubscribe"
+    When I click "Unfollow"
     Then a modal should open
-    And I should see "Unsubscribe from this discussion?" in the "Modal title" region
-    When I press "Unsubscribe" in the "Modal buttons" region
+    And I should see "Stop following this discussion?" in the "Modal title" region
+    When I press "Unfollow" in the "Modal buttons" region
     Then I should see the heading "Rare Butter"
-    And I should see the link "Subscribe"
+    And I should see the link "Follow"
     And the "Rare butter" discussion should have 0 subscribers
 
   @email
@@ -71,7 +71,7 @@ Feature: Subscribing to discussions
     And I go to the "Rare Butter" discussion
     # User 'debater' is also subscribing. We check later if, as being the author
     # of the comment, he will not receive notification.
-    And I click "Subscribe"
+    And I click "Follow"
     And I fill in "Create comment" with "I'm the moderator of this discussion. Let's talk."
     But I wait for the spam protection time limit to pass
     Then I press "Post comment"
@@ -100,8 +100,8 @@ Feature: Subscribing to discussions
     And I press "Update"
     Then 0 e-mails should have been sent
 
-    # When relevant fields of a discussion are changed, the subscribers are
-    # receiving a notifications.
+    # When relevant fields of a discussion are changed, the followers are
+    # receiving a notification.
     Given I go to the discussion content "Rare Butter" edit screen
     And I fill in "Content" with "The old content was wrong."
     And I press "Update"

--- a/web/modules/custom/joinup_discussion/joinup_discussion.behat.inc
+++ b/web/modules/custom/joinup_discussion/joinup_discussion.behat.inc
@@ -5,6 +5,8 @@
  * Contains \DiscussionSubContext.
  */
 
+declare(strict_types = 1);
+
 use Drupal\DrupalExtension\Context\DrupalSubContextBase;
 use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
 use Drupal\joinup\Traits\NodeTrait;
@@ -27,7 +29,7 @@ class JoinupDiscussionSubContext extends DrupalSubContextBase implements DrupalS
    * @When I go to the :title discussion
    * @When I visit the :title discussion
    */
-  public function visitDiscussion($title) {
+  public function visitDiscussion(string $title): void {
     /** @var \Drupal\node\Entity\Node $node */
     $node = $this->getNodeByTitle($title, 'discussion');
     $this->visitPath($node->url());
@@ -43,7 +45,7 @@ class JoinupDiscussionSubContext extends DrupalSubContextBase implements DrupalS
    *
    * @Then the :title discussion should have :count subscriber(s)
    */
-  public function assertSubscribers($title, $count) {
+  public function assertSubscribers(string $title, int $count): void {
     $discussion = $this->getNodeByTitle($title, 'discussion');
     $subscribers = $this->getSubscriptionService()->getSubscribers($discussion, 'subscribe_discussions');
     Assert::assertEquals($count, count($subscribers));

--- a/web/modules/custom/joinup_subscription/config/install/flag.flag.subscribe_discussions.yml
+++ b/web/modules/custom/joinup_subscription/config/install/flag.flag.subscribe_discussions.yml
@@ -4,18 +4,18 @@ dependencies:
   module:
     - joinup_subscription
 id: subscribe_discussions
-label: 'Subscribe discussions'
+label: 'Follow discussions'
 bundles:
   - discussion
 entity_type: node
 global: false
 weight: 0
-flag_short: Subscribe
+flag_short: Follow
 flag_long: ''
-flag_message: 'You have been subscribed to the discussion.'
-unflag_short: Unsubscribe
+flag_message: 'You are now following this discussion and you will receive notifications when someone posts a comment.'
+unflag_short: Unfollow
 unflag_long: ''
-unflag_message: 'You have been unsubscribed from the discussion.'
+unflag_message: 'You are no longer following the discussion.'
 unflag_denied_text: ''
 flag_type: 'entity:node'
 link_type: safe_unflag
@@ -27,8 +27,8 @@ flagTypeConfig:
   extra_permissions:
     owner: '0'
 linkTypeConfig:
-  flag_confirmation: 'Subscribe to this discussion?'
-  unflag_confirmation: 'Unsubscribe from this discussion?'
-  flag_create_button: Subscribe
-  flag_delete_button: Unsubscribe
+  flag_confirmation: 'Follow this discussion?'
+  unflag_confirmation: 'Stop following this discussion?'
+  flag_create_button: Follow
+  flag_delete_button: Unfollow
   form_behavior: modal


### PR DESCRIPTION
…of 'Subscribe to discussion'.