### PR TITLE
Depending on the initial computed field value being auto-created is deprecated

### DIFF
--- a/web/modules/custom/joinup_core/src/Plugin/Field/FieldType/CurrentWorkflowState.php
+++ b/web/modules/custom/joinup_core/src/Plugin/Field/FieldType/CurrentWorkflowState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\joinup_core\Plugin\Field\FieldType;
 
 use Drupal\Component\Utility\Random;
@@ -17,6 +19,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   label = @Translation("Current workflow state"),
  *   description = @Translation("Computed field that shows the current workflow state."),
  *   no_ui = TRUE,
+ *   list_class = "\Drupal\joinup_core\Plugin\Field\FieldType\CurrentWorkflowStateFieldItemList",
  *   default_widget = "current_workflow_state_widget",
  *   default_formatter = "current_workflow_state_field_formatter"
  * )

--- a/web/modules/custom/joinup_core/src/Plugin/Field/FieldType/CurrentWorkflowStateFieldItemList.php
+++ b/web/modules/custom/joinup_core/src/Plugin/Field/FieldType/CurrentWorkflowStateFieldItemList.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\joinup_core\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+/**
+ * Field item list for the current workflow state computed field.
+ */
+class CurrentWorkflowStateFieldItemList extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    // We don't need to compute an initial value since the values are set by the
+    // widget. Just set an empty value.
+    // @see \Drupal\joinup_core\Plugin\Field\FieldWidget\CurrentWorkflowStateWidget::validateFormElement()
+    $this->list[0] = $this->createItem(0, '');
+  }
+
+}


### PR DESCRIPTION
Fixes the following deprecation warning:

> Automatically creating the first item for computed fields is deprecated in Drupal 8.5.x and will be removed before Drupal 9.0.0. Use \Drupal\Core\TypedData\ComputedItemListTrait instead.

In Drupal 9 all computed fields should provide an initial value when the field is first accessed. Our `CurrentWorkflowState` computed field predates Drupal 8.5 and was not yet doing it. The fix is simple since we do not need to compute an initial value, this is set in the widget. So this PR is simply setting an empty string as the initial value.