### PR TITLE
Use the default solr url to download solr.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -135,7 +135,7 @@ solr.version = 7.7.1
 solr.tarball.filename = solr-${solr.version}.tgz
 
 # Download URL.
-solr.download.url = http://www-eu.apache.org/dist/lucene/solr/${solr.version}/${solr.tarball.filename}
+solr.download.url = http://archive.apache.org/dist/lucene/solr/${solr.version}/${solr.tarball.filename}
 
 # Installation path.
 solr.vendor.dir = ${project.basedir}/vendor/apache


### PR DESCRIPTION
Currently, we use solr 6.6 as all environments are configured for solr 6 and even CPHP is configured for solr 5. 
However, the default URL for apache solr only has links for specific versions of apahce solr 7 and 8.

**Proposed resolution**
Use the archive URL to have access to all versions of solr.