### PR TITLE
ISAICP-5984: Solve circular dependency between solution and collection modules

### DIFF
--- a/web/modules/custom/asset_release/src/Entity/AssetRelease.php
+++ b/web/modules/custom/asset_release/src/Entity/AssetRelease.php
@@ -6,6 +6,7 @@ namespace Drupal\asset_release\Entity;
 
 use Drupal\joinup_bundle_class\JoinupBundleClassFieldAccessTrait;
 use Drupal\joinup_group\Exception\MissingGroupException;
+use Drupal\joinup_workflow\EntityWorkflowStateTrait;
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\rdf_entity\RdfInterface;
 use Drupal\solution\Entity\SolutionContentTrait;
@@ -15,6 +16,7 @@ use Drupal\solution\Entity\SolutionContentTrait;
  */
 class AssetRelease extends Rdf implements AssetReleaseInterface {
 
+  use EntityWorkflowStateTrait;
   use JoinupBundleClassFieldAccessTrait;
   use SolutionContentTrait;
 
@@ -27,6 +29,13 @@ class AssetRelease extends Rdf implements AssetReleaseInterface {
       throw new MissingGroupException();
     }
     return $field_item->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWorkflowStateFieldName(): string {
+    return 'field_isr_state';
   }
 
 }

--- a/web/modules/custom/asset_release/src/Entity/AssetReleaseInterface.php
+++ b/web/modules/custom/asset_release/src/Entity/AssetReleaseInterface.php
@@ -5,12 +5,13 @@ declare(strict_types = 1);
 namespace Drupal\asset_release\Entity;
 
 use Drupal\collection\Entity\CollectionContentInterface;
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
 use Drupal\rdf_entity\RdfInterface;
 use Drupal\solution\Entity\SolutionContentInterface;
 
 /**
  * Interface for asset release entities in Joinup.
  */
-interface AssetReleaseInterface extends RdfInterface, CollectionContentInterface, SolutionContentInterface {
+interface AssetReleaseInterface extends RdfInterface, CollectionContentInterface, SolutionContentInterface, EntityWorkflowStateInterface {
 
 }

--- a/web/modules/custom/collection/collection.module
+++ b/web/modules/custom/collection/collection.module
@@ -468,30 +468,3 @@ function collection_node_delete(NodeInterface $node) {
     $group->setChangedTime(\Drupal::time()->getRequestTime())->save();
   }
 }
-
-/**
- * Implements hook_ENTITY_TYPE_delete().
- *
- * @todo This introduces a circular dependency on the solution module.
- * @see https://citnet.tech.ec.europa.eu/CITnet/jira/browse/ISAICP-5984
- */
-function collection_rdf_entity_delete(RdfInterface $solution) {
-  if (($solution->bundle() !== 'solution') || ($solution->field_is_state->value !== 'validated')) {
-    return;
-  }
-
-  $storage = \Drupal::entityTypeManager()->getStorage('rdf_entity');
-  $ids = $storage->getQuery()
-    ->condition('rid', 'collection')
-    ->condition('field_ar_affiliates', $solution->id())
-    ->execute();
-  if ($ids) {
-    // Touch the parent collections in order to update their changed timestamp.
-    $request_time = \Drupal::time()->getRequestTime();
-    /** @var \Drupal\rdf_entity\RdfInterface $collection */
-    foreach ($storage->loadMultiple($ids) as $collection) {
-      $collection->skip_notification = TRUE;
-      $collection->setChangedTime($request_time)->save();
-    }
-  }
-}

--- a/web/modules/custom/collection/src/Entity/CollectionInterface.php
+++ b/web/modules/custom/collection/src/Entity/CollectionInterface.php
@@ -5,11 +5,12 @@ declare(strict_types = 1);
 namespace Drupal\collection\Entity;
 
 use Drupal\joinup_bundle_class\ShortIdInterface;
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
 use Drupal\rdf_entity\RdfInterface;
 
 /**
  * Interface for collection entities in Joinup.
  */
-interface CollectionInterface extends RdfInterface, ShortIdInterface {
+interface CollectionInterface extends RdfInterface, ShortIdInterface, EntityWorkflowStateInterface {
 
 }

--- a/web/modules/custom/contact_information/contact_information.module
+++ b/web/modules/custom/contact_information/contact_information.module
@@ -11,6 +11,16 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\contact_information\Entity\ContactInformation;
+
+/**
+ * Implements hook_entity_bundle_info_alter().
+ */
+function contact_information_entity_bundle_info_alter(&$bundles) {
+  if (!empty($bundles['rdf_entity']['contact_information'])) {
+    $bundles['rdf_entity']['contact_information']['class'] = ContactInformation::class;
+  }
+}
 
 /**
  * Implements hook_entity_bundle_field_info_alter().

--- a/web/modules/custom/contact_information/src/Entity/ContactInformation.php
+++ b/web/modules/custom/contact_information/src/Entity/ContactInformation.php
@@ -2,27 +2,25 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\collection\Entity;
+namespace Drupal\contact_information\Entity;
 
 use Drupal\joinup_bundle_class\JoinupBundleClassFieldAccessTrait;
-use Drupal\joinup_bundle_class\ShortIdTrait;
 use Drupal\joinup_workflow\EntityWorkflowStateTrait;
 use Drupal\rdf_entity\Entity\Rdf;
 
 /**
- * Entity subclass for the 'collection' bundle.
+ * Bundle class for the 'contact_information' bundle.
  */
-class Collection extends Rdf implements CollectionInterface {
+class ContactInformation extends Rdf implements ContactInformationInterface {
 
   use EntityWorkflowStateTrait;
   use JoinupBundleClassFieldAccessTrait;
-  use ShortIdTrait;
 
   /**
    * {@inheritdoc}
    */
   public function getWorkflowStateFieldName(): string {
-    return 'field_ar_state';
+    return 'field_ci_state';
   }
 
 }

--- a/web/modules/custom/contact_information/src/Entity/ContactInformationInterface.php
+++ b/web/modules/custom/contact_information/src/Entity/ContactInformationInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\contact_information\Entity;
+
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
+use Drupal\rdf_entity\RdfInterface;
+
+/**
+ * Interface for contact information entities in Joinup.
+ */
+interface ContactInformationInterface extends RdfInterface, EntityWorkflowStateInterface {
+
+}

--- a/web/modules/custom/joinup_community_content/src/Entity/CommunityContentBase.php
+++ b/web/modules/custom/joinup_community_content/src/Entity/CommunityContentBase.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\joinup_community_content\Entity;
 
 use Drupal\collection\Entity\NodeCollectionContentTrait;
+use Drupal\joinup_workflow\EntityWorkflowStateTrait;
 use Drupal\node\Entity\Node;
 
 /**
@@ -12,6 +13,14 @@ use Drupal\node\Entity\Node;
  */
 class CommunityContentBase extends Node implements CommunityContentInterface {
 
+  use EntityWorkflowStateTrait;
   use NodeCollectionContentTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWorkflowStateFieldName(): string {
+    return 'field_state';
+  }
 
 }

--- a/web/modules/custom/joinup_community_content/src/Entity/CommunityContentInterface.php
+++ b/web/modules/custom/joinup_community_content/src/Entity/CommunityContentInterface.php
@@ -6,10 +6,11 @@ namespace Drupal\joinup_community_content\Entity;
 
 use Drupal\collection\Entity\CollectionContentInterface;
 use Drupal\joinup_group\Entity\GroupContentInterface;
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
 use Drupal\node\NodeInterface;
 
 /**
  * Interface for community content entities.
  */
-interface CommunityContentInterface extends NodeInterface, GroupContentInterface, CollectionContentInterface {
+interface CommunityContentInterface extends NodeInterface, GroupContentInterface, CollectionContentInterface, EntityWorkflowStateInterface {
 }

--- a/web/modules/custom/joinup_workflow/src/EntityWorkflowStateInterface.php
+++ b/web/modules/custom/joinup_workflow/src/EntityWorkflowStateInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\joinup_workflow;
+
+/**
+ * Interface for bundle classes that are subject to workflows.
+ */
+interface EntityWorkflowStateInterface {
+
+  /**
+   * Returns the current workflow state.
+   *
+   * @return string
+   *   The workflow state.
+   */
+  public function getWorkflowState(): string;
+
+  /**
+   * Returns the machine name of the workflow state field.
+   *
+   * @return string
+   *   The machine name.
+   */
+  public function getWorkflowStateFieldName(): string;
+
+}

--- a/web/modules/custom/joinup_workflow/src/EntityWorkflowStateTrait.php
+++ b/web/modules/custom/joinup_workflow/src/EntityWorkflowStateTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\joinup_workflow;
+
+/**
+ * Reusable methods for entities that have a workflow state field.
+ */
+trait EntityWorkflowStateTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWorkflowState(): string {
+    assert(method_exists($this, 'getMainPropertyValue'), __TRAIT__ . ' depends on JoinupBundleClassFieldAccessTrait. Please include it in your class.');
+    assert(method_exists($this, 'getWorkflowStateFieldName'), __TRAIT__ . ' depends on EntityWorkflowStateInterface. Please implement it in your class.');
+    $value = $this->getMainPropertyValue($this->getWorkflowStateFieldName());
+    return $value ? (string) $value : '__new__';
+  }
+
+}

--- a/web/modules/custom/owner/owner.module
+++ b/web/modules/custom/owner/owner.module
@@ -12,9 +12,19 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\owner\Entity\Owner;
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\rdf_entity\RdfInterface;
 use Drupal\sparql_entity_storage\Entity\Query\Sparql\SparqlArg;
+
+/**
+ * Implements hook_entity_bundle_info_alter().
+ */
+function owner_entity_bundle_info_alter(&$bundles) {
+  if (!empty($bundles['rdf_entity']['owner'])) {
+    $bundles['rdf_entity']['owner']['class'] = Owner::class;
+  }
+}
 
 /**
  * Implements hook_ENTITY_TYPE_create().

--- a/web/modules/custom/owner/src/Entity/Owner.php
+++ b/web/modules/custom/owner/src/Entity/Owner.php
@@ -2,27 +2,25 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\collection\Entity;
+namespace Drupal\owner\Entity;
 
 use Drupal\joinup_bundle_class\JoinupBundleClassFieldAccessTrait;
-use Drupal\joinup_bundle_class\ShortIdTrait;
 use Drupal\joinup_workflow\EntityWorkflowStateTrait;
 use Drupal\rdf_entity\Entity\Rdf;
 
 /**
- * Entity subclass for the 'collection' bundle.
+ * Bundle class for the 'owner' bundle.
  */
-class Collection extends Rdf implements CollectionInterface {
+class Owner extends Rdf implements OwnerInterface {
 
   use EntityWorkflowStateTrait;
   use JoinupBundleClassFieldAccessTrait;
-  use ShortIdTrait;
 
   /**
    * {@inheritdoc}
    */
   public function getWorkflowStateFieldName(): string {
-    return 'field_ar_state';
+    return 'field_owner_state';
   }
 
 }

--- a/web/modules/custom/owner/src/Entity/OwnerInterface.php
+++ b/web/modules/custom/owner/src/Entity/OwnerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\owner\Entity;
+
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
+use Drupal\rdf_entity\RdfInterface;
+
+/**
+ * Interface for owner entities in Joinup.
+ */
+interface OwnerInterface extends RdfInterface, EntityWorkflowStateInterface {
+
+}

--- a/web/modules/custom/solution/solution.module
+++ b/web/modules/custom/solution/solution.module
@@ -27,6 +27,7 @@ use Drupal\rdf_entity\Entity\RdfEntityType;
 use Drupal\rdf_entity\RdfInterface;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\solution\Entity\Solution;
+use Drupal\solution\Entity\SolutionInterface;
 use Drupal\solution\SolutionAffiliationFieldItemList;
 use Drupal\solution\SolutionReleasesAndDistributionsFieldItemList;
 use Drupal\sparql_entity_storage\SparqlGraphInterface;
@@ -581,6 +582,33 @@ function solution_rdf_entity_update(EntityInterface $entity) {
     \Drupal::entityTypeManager()->getStorage('rdf_entity')->deleteFromGraph([$entity], 'default');
   }
   solution_invalidate_collection($entity);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ *
+ * When a published solution is deleted, the parent collections should have
+ * their changed timestamp updated.
+ */
+function solution_rdf_entity_delete(RdfInterface $solution) {
+  if (!$solution instanceof SolutionInterface || $solution->getWorkflowState() !== 'validated') {
+    return;
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('rdf_entity');
+  $ids = $storage->getQuery()
+    ->condition('rid', 'collection')
+    ->condition('field_ar_affiliates', $solution->id())
+    ->execute();
+  if ($ids) {
+    // Touch the parent collections in order to update their changed timestamp.
+    $request_time = \Drupal::time()->getRequestTime();
+    /** @var \Drupal\rdf_entity\RdfInterface $collection */
+    foreach ($storage->loadMultiple($ids) as $collection) {
+      $collection->skip_notification = TRUE;
+      $collection->setChangedTime($request_time)->save();
+    }
+  }
 }
 
 /**

--- a/web/modules/custom/solution/src/Entity/Solution.php
+++ b/web/modules/custom/solution/src/Entity/Solution.php
@@ -9,6 +9,7 @@ use Drupal\collection\Exception\MissingCollectionException;
 use Drupal\joinup_bundle_class\JoinupBundleClassFieldAccessTrait;
 use Drupal\joinup_bundle_class\ShortIdTrait;
 use Drupal\joinup_group\Exception\MissingGroupException;
+use Drupal\joinup_workflow\EntityWorkflowStateTrait;
 use Drupal\rdf_entity\Entity\Rdf;
 use Drupal\rdf_entity\RdfInterface;
 
@@ -17,6 +18,7 @@ use Drupal\rdf_entity\RdfInterface;
  */
 class Solution extends Rdf implements SolutionInterface {
 
+  use EntityWorkflowStateTrait;
   use JoinupBundleClassFieldAccessTrait;
   use ShortIdTrait;
 
@@ -43,6 +45,13 @@ class Solution extends Rdf implements SolutionInterface {
       throw new MissingGroupException();
     }
     return $field_item->entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWorkflowStateFieldName(): string {
+    return 'field_is_state';
   }
 
 }

--- a/web/modules/custom/solution/src/Entity/SolutionInterface.php
+++ b/web/modules/custom/solution/src/Entity/SolutionInterface.php
@@ -6,11 +6,12 @@ namespace Drupal\solution\Entity;
 
 use Drupal\collection\Entity\CollectionContentInterface;
 use Drupal\joinup_bundle_class\ShortIdInterface;
+use Drupal\joinup_workflow\EntityWorkflowStateInterface;
 use Drupal\rdf_entity\RdfInterface;
 
 /**
  * Interface for solution entities in Joinup.
  */
-interface SolutionInterface extends RdfInterface, CollectionContentInterface, ShortIdInterface {
+interface SolutionInterface extends RdfInterface, CollectionContentInterface, EntityWorkflowStateInterface, ShortIdInterface {
 
 }


### PR DESCRIPTION
Since the affected code was accessing the workflow state directly on the `$solution->field_is_state` field and there was a generous amount of time foreseen for this ticket I have also created a new `EntityWorkflowStateInterface` class which has a method `::getWorkflowState()` and implemented it for all bundles that are using workflow.