### PR TITLE
Ensure that the Solr binary is not overwritten with a self-referential symlink

### DIFF
--- a/resources/runner/solr.yml
+++ b/resources/runner/solr.yml
@@ -4,7 +4,7 @@ solr:
   version: '6.6.6'
   vendor_dir: ${joinup.dir}/vendor/apache
   dir: ${solr.vendor_dir}/solr-${solr.version}
-  bin: ${solr.dir}/bin/solr
+  bin: ${joinup.dir}/vendor/bin/solr
   download_url: http://archive.apache.org/dist/lucene/solr/${solr.version}/solr-${solr.version}.tgz
   config_dir: ${joinup.site_dir}/modules/contrib/search_api_solr/solr-conf/6.x
   core:


### PR DESCRIPTION
In commit [2575c422](https://github.com/ec-europa/joinup-dev/commit/2575c42235b646158e621212757e455027720c65) an accidental change was introduced in the configuration that instructs the task runner to create a symlink from the Solr binary to `./vendor/bin/solr` for easy access. After this change the original Solr binary is overwritten with a self-referential symlink, making it impossible to start Solr.