### PR TITLE
RFT: publication date is 1 second later than creation date

### DIFF
--- a/tests/src/Context/JoinupCommunityContentContext.php
+++ b/tests/src/Context/JoinupCommunityContentContext.php
@@ -147,7 +147,11 @@ class JoinupCommunityContentContext extends RawDrupalContext {
       throw new \InvalidArgumentException('Node does not have a publication date field.');
     }
     Assert::assertNotEmpty($node->getPublicationTime());
-    Assert::assertEquals($node->created->value, $node->getPublicationTime());
+
+    // Since there can be minor differences in the timestamp depending on the
+    // performacne of the request, we allow a grace period of 5 milliseconds
+    // for the difference between the created and the publication date.
+    Assert::assertTrue(abs((int) $node->created->value - (int) $node->getPublicationTime()) < 5);
   }
 
   /**

--- a/tests/src/Context/JoinupCommunityContentContext.php
+++ b/tests/src/Context/JoinupCommunityContentContext.php
@@ -148,9 +148,10 @@ class JoinupCommunityContentContext extends RawDrupalContext {
     }
     Assert::assertNotEmpty($node->getPublicationTime());
 
-    // Since there can be minor differences in the timestamp depending on the
-    // performacne of the request, we allow a grace period of 5 milliseconds
-    // for the difference between the created and the publication date.
+    // Depending on the performance of the test environment it is possible that
+    // a small amount of time has passed between the moment the node was created
+    // and the moment it was published. We allow a grace period of 5 seconds to
+    // account for the difference between the created and the publication date.
     Assert::assertTrue(abs((int) $node->created->value - (int) $node->getPublicationTime()) < 5);
   }
 


### PR DESCRIPTION
We are suffering since yesterday from a frequently occurring RFT. It has been solved by @idimopoulos in scope of ISAICP-6139. This PR is cherry-picking the fix from ISAICP-6139 so that this can be merged in develop and unblock us.