### PR TITLE
Fix division by zero error in deploy hook

### DIFF
--- a/web/modules/custom/joinup_core/joinup_core.deploy.php
+++ b/web/modules/custom/joinup_core/joinup_core.deploy.php
@@ -88,6 +88,7 @@ function joinup_core_deploy_0107001(array &$sandbox): string {
   }
 
   $sandbox['progress'] += count($entity_ids);
-  $sandbox['#finished'] = (float) $sandbox['progress'] / (float) $sandbox['max'];
+  $sandbox['#finished'] = empty($sandbox['entity_ids']) ? 1 : (float) $sandbox['progress'] / (float) $sandbox['max'];
+
   return "Completed {$sandbox['progress']} out of {$sandbox['max']}.";
 }


### PR DESCRIPTION
Only happens on an empty database so will not affect production, but let's fix this anyway since it may cause lost time in development.