### PR TITLE
ISAICP-6650: Backend fixes for the In The Spotlight block

### DIFF
--- a/config/sync/views.view.in_the_spotlight.yml
+++ b/config/sync/views.view.in_the_spotlight.yml
@@ -63,56 +63,6 @@ display:
           separator: ''
           hide_empty: false
       fields:
-        counter:
-          id: counter
-          table: views
-          field: counter
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          counter_start: 1
-          plugin_id: counter
         rendered_entity:
           id: rendered_entity
           table: node
@@ -235,6 +185,8 @@ display:
         - 'config:core.entity_view_display.node.document.view_mode_tile'
         - 'config:core.entity_view_display.node.event.default'
         - 'config:core.entity_view_display.node.event.digest_message'
+        - 'config:core.entity_view_display.node.event.explore_item'
+        - 'config:core.entity_view_display.node.event.highlighted'
         - 'config:core.entity_view_display.node.event.moderation'
         - 'config:core.entity_view_display.node.event.numbered_listing'
         - 'config:core.entity_view_display.node.event.view_mode_featured'
@@ -244,6 +196,7 @@ display:
         - 'config:core.entity_view_display.node.news.dated_listing'
         - 'config:core.entity_view_display.node.news.default'
         - 'config:core.entity_view_display.node.news.digest_message'
+        - 'config:core.entity_view_display.node.news.explore_item'
         - 'config:core.entity_view_display.node.news.moderation'
         - 'config:core.entity_view_display.node.news.numbered_listing'
         - 'config:core.entity_view_display.node.news.view_mode_featured'
@@ -287,6 +240,8 @@ display:
         - 'config:core.entity_view_display.node.document.view_mode_tile'
         - 'config:core.entity_view_display.node.event.default'
         - 'config:core.entity_view_display.node.event.digest_message'
+        - 'config:core.entity_view_display.node.event.explore_item'
+        - 'config:core.entity_view_display.node.event.highlighted'
         - 'config:core.entity_view_display.node.event.moderation'
         - 'config:core.entity_view_display.node.event.numbered_listing'
         - 'config:core.entity_view_display.node.event.view_mode_featured'
@@ -296,6 +251,7 @@ display:
         - 'config:core.entity_view_display.node.news.dated_listing'
         - 'config:core.entity_view_display.node.news.default'
         - 'config:core.entity_view_display.node.news.digest_message'
+        - 'config:core.entity_view_display.node.news.explore_item'
         - 'config:core.entity_view_display.node.news.moderation'
         - 'config:core.entity_view_display.node.news.numbered_listing'
         - 'config:core.entity_view_display.node.news.view_mode_featured'

--- a/web/themes/ventuno/src/scss/components/_in-the-spotlight-block.scss
+++ b/web/themes/ventuno/src/scss/components/_in-the-spotlight-block.scss
@@ -14,6 +14,11 @@
       width: 4rem;
       @extend .pe-3;
     }
+    .metadata {
+      color: $gray-500;
+      @extend .mt-2;
+      @extend .fs-xs;
+    }
     article {
       div[class$="logo"] {
         max-width: 149px;

--- a/web/themes/ventuno/templates/content/node--numbered-listing.html.twig
+++ b/web/themes/ventuno/templates/content/node--numbered-listing.html.twig
@@ -24,5 +24,9 @@
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
     </h2>
     {{ content.body }}
+    <div class="metadata">
+      <span class="date pe-3">{{ date }}</span>
+      <span class="type">{{ type }}</span>
+    </div>
   {% endblock %}
 </article>

--- a/web/themes/ventuno/templates/content/node--numbered-listing.html.twig
+++ b/web/themes/ventuno/templates/content/node--numbered-listing.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Template for a node shown in the 'numbered listing' view mode.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    node.bundle|clean_class,
+    node.bundle|clean_class ~ '--' ~ view_mode|clean_class,
+  ]
+%}
+<article{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {{ title_suffix }}
+  {% block content %}
+    {{ logo }}
+    {{ content.field_topic }}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+    {{ content.body }}
+  {% endblock %}
+</article>

--- a/web/themes/ventuno/ventuno.theme
+++ b/web/themes/ventuno/ventuno.theme
@@ -7,6 +7,8 @@
 
 declare(strict_types = 1);
 
+use Drupal\joinup_bundle_class\LogoInterface;
+
 /**
  * Implements hook_preprocess_rdf_entity().
  */
@@ -26,4 +28,20 @@ function ventuno_preprocess_page(&$variables) {
   $joinup_version = \Drupal::service('joinup_core.joinup_version');
   $variables['version'] = $joinup_version->getVersion();
   $variables['version_url'] = $joinup_version->getUrl();
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function ventuno_preprocess_node__numbered_listing(&$variables) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $variables['node'];
+
+  // Expose the logo if it exists.
+  if ($node instanceof LogoInterface) {
+    $field_name = $node->getLogoFieldName();
+    if (!empty($variables['content'][$field_name])) {
+      $variables['logo'] = $variables['content'][$field_name];
+    }
+  }
 }

--- a/web/themes/ventuno/ventuno.theme
+++ b/web/themes/ventuno/ventuno.theme
@@ -44,4 +44,12 @@ function ventuno_preprocess_node__numbered_listing(&$variables) {
       $variables['logo'] = $variables['content'][$field_name];
     }
   }
+
+  // Provide date using the date format that is standardized site wide.
+  /** @var \Drupal\Core\Datetime\DateFormatterInterface $date_formatter */
+  $date_formatter = \Drupal::service('date.formatter');
+  $variables['date'] = $date_formatter->format($node->getCreatedTime(), 'date_only');
+
+  // Provide the content type.
+  $variables['type'] = $node->type->entity->label();
 }


### PR DESCRIPTION
Adapts the following:

1. Move the title underneath the Topics badges
1. Show the date and content type (note that the date is using a different date format than is used in the design mockups. The UX designer is not aware of a previous decision to consistently use DD/MM/YYYY across the entire website)
1. Hide the result counter so it can be implemented using CSS